### PR TITLE
fix: flaky test

### DIFF
--- a/crates/relayer/src/error.rs
+++ b/crates/relayer/src/error.rs
@@ -68,6 +68,9 @@ pub(crate) enum RecoverableError {
     /// The stream returned an error.
     #[error("the stream returned an error: {0}")]
     StreamError(String),
+    /// A DB error occurred.
+    #[error("a DB error occurred: {0}")]
+    Rusqlite(rusqlite::Error),
 }
 
 #[derive(Debug, Error)]

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -263,13 +263,12 @@ impl GetConn for Conn {
 
 pub async fn setup_server() -> (String, Child) {
     let mut child = Command::new("essential-rest-server")
-        .env("RUST_LOG", "[run_loop]=debug,info")
         .arg("--db")
         .arg("memory")
         .arg("0.0.0.0:0")
         .arg("--loop-freq")
         .arg("1")
-        // .arg("--disable-tracing")
+        .arg("--disable-tracing")
         .kill_on_drop(true)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
There are a few rusqlite errors we were handling as critical but were actually recoverable. This maps those to recoverable and fixes the flaky test.