### PR TITLE
feat: Make API TCP connection limit configurable

### DIFF
--- a/crates/node-api/tests/util.rs
+++ b/crates/node-api/tests/util.rs
@@ -68,7 +68,7 @@ where
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
     let api_jh = tokio::spawn(async move {
         tokio::select! {
-            _ = node_api::serve(&router, &listener) => {},
+            _ = node_api::serve(&router, &listener, node_api::DEFAULT_CONNECTION_LIMIT) => {},
             _ = shutdown_rx => {},
         }
     });

--- a/crates/node-cli/src/main.rs
+++ b/crates/node-cli/src/main.rs
@@ -33,6 +33,9 @@ struct Args {
     /// Disable the tracing subscriber.
     #[arg(long, default_value_t = false)]
     disable_tracing: bool,
+    /// The maximum number of TCP streams to be served simultaneously.
+    #[arg(long, default_value_t = node_api::DEFAULT_CONNECTION_LIMIT)]
+    tcp_conn_limit: usize,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug)]
@@ -112,7 +115,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(args.bind_address).await?;
     #[cfg(feature = "tracing")]
     tracing::info!("Starting API server at {}", listener.local_addr()?);
-    let api = node_api::serve(&router, &listener);
+    let api = node_api::serve(&router, &listener, args.tcp_conn_limit);
 
     // Select the first future to complete to close.
     let ctrl_c = tokio::signal::ctrl_c();


### PR DESCRIPTION
After landing #24 I realised the TCP connection limit was hard-coded while the DB connection limit was configurable. This adds a `tcp-conn-limit` flag to the node CLI to allow for configuring the connection limit.

Related #11.