### PR TITLE
fix: Incorrect subdir for node-cli toml in nix pkg

### DIFF
--- a/pkgs/essential-node.nix
+++ b/pkgs/essential-node.nix
@@ -28,7 +28,8 @@ let
         lib.lists.any (dir: isPathInIncludeDirs dir) includeDirs
     ;
   };
-  crateDir = "${src}/crates/node-api";
+  crateSubdir = "crates/node-cli";
+  crateDir = "${src}/${crateSubdir}";
   crateTOML = "${crateDir}/Cargo.toml";
   lockFile = "${src}/Cargo.lock";
 in
@@ -37,7 +38,7 @@ rustPlatform.buildRustPackage {
   pname = "essential-node";
   version = (builtins.fromTOML (builtins.readFile crateTOML)).package.version;
 
-  buildAndTestSubdir = "crates/node-cli";
+  buildAndTestSubdir = crateSubdir;
 
   OPENSSL_NO_VENDOR = 1;
 


### PR DESCRIPTION
Fixes a small bug where I missed changing the subdir used for reading the crate toml which was used for the pkg version.