### PR TITLE
test: set `foreign_keys` to true in relevant tests

### DIFF
--- a/crates/node-db/tests/create.rs
+++ b/crates/node-db/tests/create.rs
@@ -1,9 +1,11 @@
 use essential_node_db as node_db;
-use rusqlite::Connection;
+use util::test_conn;
+
+mod util;
 
 #[test]
 fn create_tables() {
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     tx.commit().unwrap();

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -3,9 +3,9 @@
 use essential_hash::content_addr;
 use essential_node_db::{self as node_db, decode};
 use essential_types::{predicate::Predicate, ContentAddress, Hash, Key, Value};
-use rusqlite::{params, Connection};
+use rusqlite::params;
 use std::time::Duration;
-use util::{test_blocks, test_blocks_with_vars};
+use util::{test_blocks, test_blocks_with_vars, test_conn};
 
 mod util;
 
@@ -15,7 +15,7 @@ fn test_insert_block() {
     let (_contract_addr, blocks) = test_blocks_with_vars(10);
 
     // Create an in-memory SQLite database
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the block.
     let tx = conn.transaction().unwrap();
@@ -141,7 +141,7 @@ fn test_finalize_block() {
     let blocks = util::test_blocks(NUM_BLOCKS);
 
     // Create an in-memory SQLite database
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the block.
     let tx = conn.transaction().unwrap();
@@ -227,7 +227,7 @@ fn test_failed_block() {
     let blocks = util::test_blocks(NUM_BLOCKS);
 
     // Create an in-memory SQLite database
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the block.
     let tx = conn.transaction().unwrap();
@@ -283,7 +283,7 @@ fn test_fork_block() {
     let fork_b = util::test_block(1, Duration::from_secs(2));
 
     // Create an in-memory SQLite database
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
@@ -312,7 +312,7 @@ fn test_insert_contract() {
     let block_n = 69;
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the contract.
     let tx = conn.transaction().unwrap();
@@ -360,7 +360,7 @@ fn test_insert_contract() {
 
 #[test]
 fn test_insert_contract_progress() {
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     node_db::insert_contract_progress(&tx, 0, &ContentAddress([0; 32]))
@@ -417,7 +417,7 @@ fn test_update_state_progress() {
     let blocks = test_blocks(2);
     let block_addresses = blocks.iter().map(content_addr).collect::<Vec<_>>();
 
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     for block in &blocks {
@@ -474,7 +474,7 @@ fn test_update_validation_progress() {
     let blocks = test_blocks(2);
     let block_addresses = blocks.iter().map(content_addr).collect::<Vec<_>>();
 
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     for block in &blocks {

--- a/crates/node-db/tests/query.rs
+++ b/crates/node-db/tests/query.rs
@@ -1,9 +1,8 @@
 use essential_hash::content_addr;
 use essential_node_db::{self as node_db};
 use essential_types::{contract::Contract, ContentAddress, Word};
-use rusqlite::Connection;
 use std::time::Duration;
-use util::{test_block, test_blocks_with_vars};
+use util::{test_block, test_blocks_with_vars, test_conn};
 
 mod util;
 
@@ -15,7 +14,7 @@ fn get_contract_salt() {
     let contract = util::test_contract(seed);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert a contract.
     let tx = conn.transaction().unwrap();
@@ -38,7 +37,7 @@ fn get_contract_predicates() {
     let contract = util::test_contract(seed);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert a contract.
     let tx = conn.transaction().unwrap();
@@ -63,7 +62,7 @@ fn test_get_contract() {
     let contract = util::test_contract(seed);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert a contract.
     let tx = conn.transaction().unwrap();
@@ -81,7 +80,7 @@ fn test_get_contract() {
 #[test]
 fn test_get_contract_progress() {
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the contract progress.
     let tx = conn.transaction().unwrap();
@@ -104,7 +103,7 @@ fn test_get_predicate() {
     let contract = util::test_contract(seed);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert a contract.
     let tx = conn.transaction().unwrap();
@@ -126,7 +125,7 @@ fn test_get_solution() {
     let block = util::test_block(42, Duration::from_secs(69));
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the block.
     let tx = conn.transaction().unwrap();
@@ -149,7 +148,7 @@ fn test_get_state_progress() {
     let block_address = content_addr(&block);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the contract progress.
     let tx = conn.transaction().unwrap();
@@ -171,7 +170,7 @@ fn test_get_validation_progress() {
     let block_address = content_addr(&block);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert the contract progress.
     let tx = conn.transaction().unwrap();
@@ -192,7 +191,7 @@ fn test_list_blocks() {
     let blocks = util::test_blocks(100);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert blocks.
     let tx = conn.transaction().unwrap();
@@ -213,7 +212,7 @@ fn test_list_blocks_by_time() {
     let blocks = util::test_blocks(10);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert blocks.
     let tx = conn.transaction().unwrap();
@@ -255,7 +254,7 @@ fn test_list_contracts() {
         .collect();
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
 
     // Create the necessary tables and insert contracts.
     let tx = conn.transaction().unwrap();
@@ -290,7 +289,7 @@ fn test_query_at_finalized() {
     let (contract_addr, blocks) = test_blocks_with_vars(10);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     for block in &blocks {

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -7,7 +7,10 @@ mod util;
 
 fn new_mem_conn(unique_id: &str) -> rusqlite::Result<Connection> {
     let conn_str = format!("file:/{unique_id}");
-    rusqlite::Connection::open_with_flags_and_vfs(conn_str, Default::default(), "memdb")
+    let conn =
+        rusqlite::Connection::open_with_flags_and_vfs(conn_str, Default::default(), "memdb")?;
+    conn.pragma_update(None, "foreign_keys", true)?;
+    Ok(conn)
 }
 
 struct AcquireConn(AsyncConnectionPool);

--- a/crates/node-db/tests/update.rs
+++ b/crates/node-db/tests/update.rs
@@ -2,7 +2,7 @@
 
 use essential_node_db as node_db;
 use essential_types::{Key, Value};
-use rusqlite::Connection;
+use util::test_conn;
 
 mod util;
 
@@ -16,7 +16,7 @@ fn test_state_value() {
     let value = Value::from([0xCD; 32]);
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     node_db::insert_contract(&tx, &contract, da_block).unwrap();
@@ -52,7 +52,7 @@ fn test_state_values_with_deletion() {
     }
 
     // Create an in-memory SQLite database.
-    let mut conn = Connection::open_in_memory().unwrap();
+    let mut conn = test_conn();
     let tx = conn.transaction().unwrap();
 
     // Create tables, contract, insert values.

--- a/crates/node-db/tests/util.rs
+++ b/crates/node-db/tests/util.rs
@@ -6,7 +6,14 @@ use essential_types::{
     solution::{Mutation, Solution, SolutionData},
     Block, ConstraintBytecode, ContentAddress, PredicateAddress, StateReadBytecode, Word,
 };
+use rusqlite::Connection;
 use std::time::Duration;
+
+pub fn test_conn() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.pragma_update(None, "foreign_keys", true).unwrap();
+    conn
+}
 
 pub fn test_blocks_with_vars(n: u64) -> (ContentAddress, Vec<Block>) {
     let mut values = 0..Word::MAX;

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -126,11 +126,13 @@ async fn test_sync() {
 fn new_conn_pool() -> AsyncConnectionPool {
     let id = uuid::Uuid::new_v4().to_string();
     AsyncConnectionPool::new(3, || {
-        rusqlite::Connection::open_with_flags_and_vfs(
+        let conn = rusqlite::Connection::open_with_flags_and_vfs(
             format!("file:/{}", id),
             Default::default(),
             "memdb",
-        )
+        )?;
+        conn.pragma_update(None, "foreign_keys", true)?;
+        Ok(conn)
     })
     .unwrap()
 }


### PR DESCRIPTION
Followup to #84 for tests that do not create Connection using `node::db` method.
Skipped `rusqlite-pool` crate's tests since those tests do not use node db tables.