### PR TITLE
docs: license, cargo manifests, READMEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite-pool"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "crossbeam",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,4 @@ essential-node-api = { path = "crates/node-api", version = "0.1.0" }
 essential-node-db-sql = { path = "crates/node-db-sql", version = "0.1.0" }
 essential-node-db = { path = "crates/node-db", version = "0.1.0" }
 essential-relayer = { path = "crates/relayer", version = "0.1.0" }
-rusqlite-pool = { path = "crates/rusqlite-pool", version = "0.0.0" }
+rusqlite-pool = { path = "crates/rusqlite-pool", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ resolver = "2"
 edition = "2021"
 authors = ["Essential Contributions <contact@essentialcontributions.com>"]
 homepage = "https://essential.builders/"
+license = "Apache-2.0"
 repository = "https://github.com/essential-contributions/essential-node"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+Derive current head from essential builder and sync state between nodes.

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "essential-node-api"
 version = "0.1.0"
-description = "API for essential node"
-edition.workspace = true
+description = "API for essential node."
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/node-api/README.md
+++ b/crates/node-api/README.md
@@ -1,17 +1,17 @@
-# Essential Node
+# essential-node-api
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
 
-[crates-badge]: https://img.shields.io/crates/v/essential-node.svg
-[crates-url]: https://crates.io/crates/essential-node
-[docs-badge]: https://docs.rs/essential-node/badge.svg
-[docs-url]: https://docs.rs/essential-node
+[crates-badge]: https://img.shields.io/crates/v/essential-node-api.svg
+[crates-url]: https://crates.io/crates/essential-node-api
+[docs-badge]: https://docs.rs/essential-node-api/badge.svg
+[docs-url]: https://docs.rs/essential-node-api
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
 [apache-url]: LICENSE
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+API for essential node.

--- a/crates/node-cli/Cargo.toml
+++ b/crates/node-cli/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "essential-node-cli"
-description = "Essential Node CLI"
 version = "0.1.0"
-edition.workspace = true
+description = "Essential node CLI."
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [[bin]]

--- a/crates/node-cli/README.md
+++ b/crates/node-cli/README.md
@@ -1,17 +1,17 @@
-# Essential Node
+# essential-node-cli
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
 
-[crates-badge]: https://img.shields.io/crates/v/essential-node.svg
-[crates-url]: https://crates.io/crates/essential-node
-[docs-badge]: https://docs.rs/essential-node/badge.svg
-[docs-url]: https://docs.rs/essential-node
+[crates-badge]: https://img.shields.io/crates/v/essential-node-cli.svg
+[crates-url]: https://crates.io/crates/essential-node-cli
+[docs-badge]: https://docs.rs/essential-node-cli/badge.svg
+[docs-url]: https://docs.rs/essential-node-cli
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
 [apache-url]: LICENSE
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+Essential node CLI.

--- a/crates/node-db-sql/Cargo.toml
+++ b/crates/node-db-sql/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "essential-node-db-sql"
 version = "0.1.0"
-description = "SQL statements for the essential node DB"
-edition.workspace = true
+description = "SQL statements for the essential node database."
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 repository.workspace = true

--- a/crates/node-db-sql/README.md
+++ b/crates/node-db-sql/README.md
@@ -1,17 +1,17 @@
-# Essential Node
+# essential-node-db-sql
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
 
-[crates-badge]: https://img.shields.io/crates/v/essential-node.svg
-[crates-url]: https://crates.io/crates/essential-node
-[docs-badge]: https://docs.rs/essential-node/badge.svg
-[docs-url]: https://docs.rs/essential-node
+[crates-badge]: https://img.shields.io/crates/v/essential-node-db-sql.svg
+[crates-url]: https://crates.io/crates/essential-node-db-sql
+[docs-badge]: https://docs.rs/essential-node-db-sql/badge.svg
+[docs-url]: https://docs.rs/essential-node-db-sql
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
 [apache-url]: LICENSE
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+SQL statements for the essential node database.

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "essential-node-db"
 version = "0.1.0"
-description = "Database for essential node"
-edition.workspace = true
+description = "Database for essential node."
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/node-db/README.md
+++ b/crates/node-db/README.md
@@ -1,17 +1,17 @@
-# Essential Node
+# essential-node-db
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
 
-[crates-badge]: https://img.shields.io/crates/v/essential-node.svg
-[crates-url]: https://crates.io/crates/essential-node
-[docs-badge]: https://docs.rs/essential-node/badge.svg
-[docs-url]: https://docs.rs/essential-node
+[crates-badge]: https://img.shields.io/crates/v/essential-node-db.svg
+[crates-url]: https://crates.io/crates/essential-node-db
+[docs-badge]: https://docs.rs/essential-node-db/badge.svg
+[docs-url]: https://docs.rs/essential-node-db
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
 [apache-url]: LICENSE
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+Database for essential node.

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "essential-node"
 version = "0.1.0"
-description = "Derive state from essential protocol"
-edition.workspace = true
+description = "State derivation and validation for essential protocol."
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -1,4 +1,4 @@
-# Essential Node
+# essential-node
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
@@ -14,4 +14,4 @@
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+State derivation and validation for essential protocol.

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-relayer"
 version = "0.1.0"
-description = "Relay blocks from L1 to essential node."
+description = "Relay blocks from essential builder to essential node."
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+name = "essential-relayer"
+version = "0.1.0"
+description = "Relay blocks from L1 to essential node."
 authors.workspace = true
-description = "Relay blocks and contracts from L1 to node"
 edition.workspace = true
 homepage.workspace = true
-name = "essential-relayer"
+license.workspace = true
 repository.workspace = true
-version = "0.1.0"
 
 [dependencies]
 essential-hash.workspace = true

--- a/crates/relayer/README.md
+++ b/crates/relayer/README.md
@@ -1,17 +1,17 @@
-# Essential Node
+# essential-relayer
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
 
-[crates-badge]: https://img.shields.io/crates/v/essential-node.svg
-[crates-url]: https://crates.io/crates/essential-node
-[docs-badge]: https://docs.rs/essential-node/badge.svg
-[docs-url]: https://docs.rs/essential-node
+[crates-badge]: https://img.shields.io/crates/v/essential-relayer.svg
+[crates-url]: https://crates.io/crates/essential-relayer
+[docs-badge]: https://docs.rs/essential-relayer/badge.svg
+[docs-url]: https://docs.rs/essential-relayer
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
 [apache-url]: LICENSE
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+Relay blocks from L1 to essential node.

--- a/crates/relayer/README.md
+++ b/crates/relayer/README.md
@@ -14,4 +14,4 @@
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Relay blocks from L1 to essential node.
+Relay blocks from essential builder to essential node.

--- a/crates/relayer/src/lib.rs
+++ b/crates/relayer/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(missing_docs)]
 //! Relayer is a library that syncs data from a remote source into a local database.
-//! The relayer syncs contracts and blocks.
+//! The relayer syncs blocks.
 //! There are notify channels to signal when new data has been synced.
 
 use error::CriticalError;
@@ -43,7 +43,7 @@ impl Relayer {
     }
 
     /// Run the relayer client.
-    /// This will sync contracts and blocks from the remote source into the local database.
+    /// This will sync blocks from the remote source into the local database.
     ///
     /// Streams are spawned and run in the background.
     /// A handle is returned that can be used to close or join the streams.

--- a/crates/rusqlite-pool/Cargo.toml
+++ b/crates/rusqlite-pool/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "rusqlite-pool"
-version = "0.0.0"
+version = "0.1.0"
 description = "A minimal connection pool for rusqlite."
-edition.workspace = true
 authors.workspace = true
+edition.workspace = true
 homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/crates/rusqlite-pool/README.md
+++ b/crates/rusqlite-pool/README.md
@@ -14,4 +14,13 @@
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-A minimal connection pool for rusqlite.
+A minimal connection pool for rusqlite, suitable for async and multi-threaded usage.
+
+Provides connection pools and handles for sync and async usages:
+
+-   `ConnectionPool`: A fixed-capacity, thread-safe queue of [`rusqlite::Connection`](https://docs.rs/rusqlite/latest/rusqlite/struct.Connection.html#)s available for usage.
+-   `ConnectionHandle`: A temporary handle to a connection.
+-   `AsyncConnectionPool`: A thin wrapper around `ConnectionPool` that uses [Semaphore](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html)s for orderly async access to database connections.
+-   `AsyncConnectionHandle`: A thin wrapper around `ConnectionHandle` that manages the associated [SemaphorePermit](https://docs.rs/tokio/latest/tokio/sync/struct.SemaphorePermit.html).
+
+The async counterparts are behind feature `tokio`.

--- a/crates/rusqlite-pool/README.md
+++ b/crates/rusqlite-pool/README.md
@@ -1,17 +1,17 @@
-# Essential Node
+# rusqlite-pool
 
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
 [![Build Status][actions-badge]][actions-url]
 
-[crates-badge]: https://img.shields.io/crates/v/essential-node.svg
-[crates-url]: https://crates.io/crates/essential-node
-[docs-badge]: https://docs.rs/essential-node/badge.svg
-[docs-url]: https://docs.rs/essential-node
+[crates-badge]: https://img.shields.io/crates/v/rusqlite-pool.svg
+[crates-url]: https://crates.io/crates/rusqlite-pool
+[docs-badge]: https://docs.rs/rusqlite-pool/badge.svg
+[docs-url]: https://docs.rs/rusqlite-pool
 [apache-badge]: https://img.shields.io/badge/license-APACHE-blue.svg
 [apache-url]: LICENSE
 [actions-badge]: https://github.com/essential-contributions/essential-node/workflows/ci/badge.svg
 [actions-url]: https://github.com/essential-contributions/essential-node/actions
 
-Derive current head from L1 and sync state between nodes.
+A minimal connection pool for rusqlite.


### PR DESCRIPTION
- Adds Apache 2.0 license.
- Fills missing fields in cargo manifests.
- Adds READMEs.
  - Elaborating crates in more detail in the READMEs, other than `rusqlite-pool`, is dangerous as the READMEs also have to be maintained in the case of a change to the code, which is expected to happen a lot over the coming weeks.

Closes #83 