### PR TITLE
fix: Various small fixes for state derivation and validation streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "essential-check",
  "essential-constraint-asm",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node-api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum",
  "essential-hash",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 
-essential-node = { path = "crates/node", version = "0.6.0" }
-essential-node-api = { path = "crates/node-api", version = "0.6.0" }
+essential-node = { path = "crates/node", version = "0.7.0" }
+essential-node-api = { path = "crates/node-api", version = "0.7.0" }
 essential-node-db-sql = { path = "crates/node-db-sql", version = "0.3.0" }
 essential-node-db = { path = "crates/node-db", version = "0.3.0" }
 essential-node-types = { path = "crates/node-types", version = "0.1.0" }

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-api"
-version = "0.6.0"
+version = "0.7.0"
 description = "API implementation for the Essential node"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node-cli/Cargo.toml
+++ b/crates/node-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "The Essential node CLI"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node-cli/src/main.rs
+++ b/crates/node-cli/src/main.rs
@@ -218,9 +218,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
     )?;
     let node_future = async move {
         if relayer_source_endpoint.is_none() && disable_state_derivation && disable_validation {
-            node_handle.join().await
-        } else {
             std::future::pending().await
+        } else {
+            node_handle.join().await
         }
     };
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node"
-version = "0.6.0"
+version = "0.7.0"
 description = "State derivation and validation for Essential protocol"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node/src/error.rs
+++ b/crates/node/src/error.rs
@@ -8,6 +8,20 @@ use tokio::sync::AcquireError;
 #[error("Connection pool creation failed: {0}")]
 pub struct ConnPoolNewError(#[from] pub rusqlite::Error);
 
+/// Errors that can occur when joining the node handle.
+#[derive(Debug, Error)]
+pub enum NodeHandleJoinError {
+    /// The relayer stream joined with an error.
+    #[error("the relayer stream returned with an error: {0}")]
+    Relayer(essential_relayer::Error),
+    /// The state derivation stream joined with an error.
+    #[error("the state derivation stream returned with an error: {0}")]
+    StateDerivation(CriticalError),
+    /// The validation stream joined with an error.
+    #[error("the validation stream returned with an error: {0}")]
+    Validation(CriticalError),
+}
+
 #[derive(Debug, Error)]
 pub(super) enum InternalError {
     #[error(transparent)]
@@ -22,8 +36,6 @@ pub enum RecoverableError {
     FirstBlockNotFound,
     #[error("block {0} not found")]
     BlockNotFound(ContentAddress),
-    #[error("no next block found after block {0}")]
-    NextBlockNotFound(ContentAddress),
     #[error("could not read state")]
     ReadState(AcquireThenQueryError),
     #[error(transparent)]


### PR DESCRIPTION
## Node Handle `join` fixes

This changes the node handle's `join` implementation to use `try_join!` internally rather than `select!`. This means that we return early in the case that any of the streams error, but in the case that a stream closes successfully we also wait for the other streams to close successfully.

This fixes a bug in both the node and builder CLIs where the validation stream can end before the state derivation stream, which would result in closing the node DB early while the state derivation stream is still using it.

## Node CLI branch mismatch

Also fixes mismatched branches in the node CLI for pending future in the case that no node streams are enabled.

## Streams check available DB blocks before awaiting channel

Also fixes the behaviour for state derivation and validation in the case that no relayer is provided. Rather than returning immediately due to the block notification channel closing, we re-arrange the stream logic to first validate or derive state from all available blocks in the DB from the current progress point, and then wait on the block notification channel only after we have reached the head of the chain.