### PR TITLE
feat: Replace `get_block_number` with more general `get_block_header`

### DIFF
--- a/crates/node-db-sql/sql/query/get_block_header.sql
+++ b/crates/node-db-sql/sql/query/get_block_header.sql
@@ -1,0 +1,11 @@
+
+SELECT
+    block.number,
+    block.timestamp_secs,
+    block.timestamp_nanos
+FROM
+    block
+WHERE
+    block.block_address = :block_address
+LIMIT
+    1;

--- a/crates/node-db-sql/sql/query/get_block_number.sql
+++ b/crates/node-db-sql/sql/query/get_block_number.sql
@@ -1,8 +1,0 @@
-SELECT
-    block.number
-FROM
-    block
-WHERE
-    block.block_address = :block_address
-LIMIT
-    1;

--- a/crates/node-db-sql/src/lib.rs
+++ b/crates/node-db-sql/src/lib.rs
@@ -48,7 +48,7 @@ pub mod insert {
 
 /// Statements for making queries.
 pub mod query {
-    decl_const_sql_str!(GET_BLOCK_NUMBER, "query/get_block_number.sql");
+    decl_const_sql_str!(GET_BLOCK_HEADER, "query/get_block_header.sql");
     decl_const_sql_str!(GET_LATEST_BLOCK_NUMBER, "query/get_latest_block_number.sql");
     decl_const_sql_str!(
         GET_LATEST_FINALIZED_BLOCK_ADDRESS,

--- a/crates/node/src/state_derivation.rs
+++ b/crates/node/src/state_derivation.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use essential_hash::content_addr;
 use essential_node_db::{
-    get_block_number, get_latest_finalized_block_address, update_state, update_state_progress,
+    get_block_header, get_latest_finalized_block_address, update_state, update_state_progress,
 };
 use essential_types::{solution::Mutation, Block, ContentAddress, Word};
 use tokio::sync::watch;
@@ -134,8 +134,9 @@ async fn get_next_block(
             let tx = conn.transaction().map_err(RecoverableError::Rusqlite)?;
             let range = match &progress {
                 Some(block_address) => {
-                    let block_number = essential_node_db::get_block_number(&tx, block_address)
+                    let block_number = get_block_header(&tx, block_address)
                         .map_err(RecoverableError::Rusqlite)?
+                        .map(|(number, _ts)| number)
                         .ok_or(RecoverableError::BlockNotFound(block_address.clone()))?;
                     block_number..block_number.saturating_add(2)
                 }
@@ -199,8 +200,12 @@ where
         let tx = conn.transaction();
         let latest_finalized_block_number = tx.and_then(|tx| {
             get_latest_finalized_block_address(&tx).and_then(|hash| {
-                hash.and_then(|hash| get_block_number(&tx, &hash).transpose())
-                    .transpose()
+                hash.and_then(|hash| {
+                    get_block_header(&tx, &hash)
+                        .map(|opt| opt.map(|(number, _ts)| number))
+                        .transpose()
+                })
+                .transpose()
             })
         });
         match latest_finalized_block_number {

--- a/crates/node/src/validate.rs
+++ b/crates/node/src/validate.rs
@@ -86,7 +86,9 @@ pub async fn validate_solution(
     let mut conn = conn_pool.acquire().await?;
     let tx = conn.transaction()?;
     let number = match essential_node_db::get_latest_finalized_block_address(&tx)? {
-        Some(address) => essential_node_db::get_block_number(&tx, &address)?.unwrap_or(1),
+        Some(address) => essential_node_db::get_block_header(&tx, &address)?
+            .map(|(number, _ts)| number)
+            .unwrap_or(1),
         None => 1,
     };
     let block = Block {

--- a/crates/relayer/src/sync.rs
+++ b/crates/relayer/src/sync.rs
@@ -35,7 +35,8 @@ pub async fn get_block_progress(
         else {
             return Ok(None);
         };
-        let Some(block_number) = essential_node_db::get_block_number(&tx, &block_address)? else {
+        let Some((block_number, _ts)) = essential_node_db::get_block_header(&tx, &block_address)?
+        else {
             return Ok(None);
         };
         tx.finish()?;


### PR DESCRIPTION
Prior to this PR, the only way to acquire the timestamp for a block given its address was to first get the block number, then list out the blocks.

This replaces `get_block_number` with a more generally useful `get_block_header` query fn that returns all header info for a block (currently just the number and timestamp).

Closes #76.