### PR TITLE
feat: update query-state endpoint, add query-state-range endpoint

### DIFF
--- a/crates/node-api/src/endpoint.rs
+++ b/crates/node-api/src/endpoint.rs
@@ -39,6 +39,8 @@ pub enum Error {
     HexDecode(#[from] hex::FromHexError),
     #[error("DB query failed: {0}")]
     ConnPoolQuery(#[from] db::AcquireThenQueryError),
+    #[error("Invalid query range: {0}. {}", query_state_range::HELP_MSG)]
+    InvalidQueryRange(query_state_range::QueryStateRange),
 }
 
 /// An error produced by a subscription endpoint stream.
@@ -62,7 +64,10 @@ impl IntoResponse for Error {
             Error::ConnPoolQuery(e) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
             }
-            Error::HexDecode(e) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+            e @ Error::HexDecode(_) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+            e @ Error::InvalidQueryRange(_) => {
+                (StatusCode::BAD_REQUEST, e.to_string()).into_response()
+            }
         }
     }
 }
@@ -114,7 +119,115 @@ pub mod query_state {
         let contract_ca: ContentAddress = contract_ca.parse()?;
         let key: Vec<u8> = hex::decode(key)?;
         let key = key_words_from_bytes(&key);
-        let value = state.conn_pool.query_state(contract_ca, key).await?;
+        // TODO: When state derivation actually compacts state and discards blocks,
+        // this query should fall back to querying compacted state.
+
+        // TODO: When blocks aren't immediately finalized, this query will need to
+        // either take a block address or use a fork choice rule to determine the
+        // latest state to return. It's possible this query won't make much sense
+        // at that point.
+
+        let value = state
+            .conn_pool
+            .query_latest_finalized_block(contract_ca, key)
+            .await?;
+        Ok(Json(value))
+    }
+}
+
+/// The `query-state` get endpoint.
+///
+/// Takes a contract content address and a byte array key as path parameters,
+/// both encoded as hex.
+pub mod query_state_range {
+    use std::fmt::Display;
+
+    use serde::Serialize;
+
+    use super::*;
+
+    pub const HELP_MSG: &str = r#"
+The query range must be one of the following combinations:
+    - block_inclusive
+    - block_exclusive
+    - block_inclusive, solution_inclusive
+    - block_inclusive, solution_exclusive
+"#;
+
+    #[derive(Deserialize, Serialize, Default, Debug)]
+    pub struct QueryStateRange {
+        pub block_inclusive: Option<Word>,
+        pub block_exclusive: Option<Word>,
+        pub solution_inclusive: Option<u64>,
+        pub solution_exclusive: Option<u64>,
+    }
+
+    impl Display for QueryStateRange {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "block_inclusive: {:?}, block_exclusive: {:?}, solution_inclusive: {:?}, solution_exclusive: {:?}",
+                self.block_inclusive, self.block_exclusive, self.solution_inclusive, self.solution_exclusive
+            )
+        }
+    }
+
+    pub const PATH: &str = "/query-state-range/:contract-ca/:key";
+    pub async fn handler(
+        State(state): State<crate::State>,
+        Path((contract_ca, key)): Path<(String, String)>,
+        Query(range): Query<QueryStateRange>,
+    ) -> Result<Json<Option<Value>>, Error> {
+        let contract_ca: ContentAddress = contract_ca.parse()?;
+        let key: Vec<u8> = hex::decode(key)?;
+        let key = key_words_from_bytes(&key);
+        let value = match range {
+            QueryStateRange {
+                block_inclusive: Some(block),
+                block_exclusive: None,
+                solution_inclusive: None,
+                solution_exclusive: None,
+            } => {
+                state
+                    .conn_pool
+                    .query_state_finalized_inclusive_block(contract_ca, key, block)
+                    .await?
+            }
+            QueryStateRange {
+                block_inclusive: None,
+                block_exclusive: Some(block),
+                solution_inclusive: None,
+                solution_exclusive: None,
+            } => {
+                state
+                    .conn_pool
+                    .query_state_finalized_exclusive_block(contract_ca, key, block)
+                    .await?
+            }
+            QueryStateRange {
+                block_inclusive: Some(block),
+                block_exclusive: None,
+                solution_inclusive: Some(solution_ix),
+                solution_exclusive: None,
+            } => {
+                state
+                    .conn_pool
+                    .query_state_finalized_inclusive_solution(contract_ca, key, block, solution_ix)
+                    .await?
+            }
+            QueryStateRange {
+                block_inclusive: Some(block),
+                block_exclusive: None,
+                solution_inclusive: None,
+                solution_exclusive: Some(solution_ix),
+            } => {
+                state
+                    .conn_pool
+                    .query_state_finalized_exclusive_solution(contract_ca, key, block, solution_ix)
+                    .await?
+            }
+            _ => return Err(Error::InvalidQueryRange(range)),
+        };
         Ok(Json(value))
     }
 }

--- a/crates/node-api/src/endpoint.rs
+++ b/crates/node-api/src/endpoint.rs
@@ -39,8 +39,11 @@ pub enum Error {
     HexDecode(#[from] hex::FromHexError),
     #[error("DB query failed: {0}")]
     ConnPoolQuery(#[from] db::AcquireThenQueryError),
-    #[error("Invalid query range: {0}. {}", query_state_range::HELP_MSG)]
-    InvalidQueryRange(query_state_range::QueryStateRange),
+    #[error(
+        "Invalid query parameter for /query-state: {0}. {}",
+        query_state::HELP_MSG
+    )]
+    InvalidQueryParameters(query_state::QueryStateParams),
 }
 
 /// An error produced by a subscription endpoint stream.
@@ -65,7 +68,7 @@ impl IntoResponse for Error {
                 (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
             }
             e @ Error::HexDecode(_) => (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
-            e @ Error::InvalidQueryRange(_) => {
+            e @ Error::InvalidQueryParameters(_) => {
                 (StatusCode::BAD_REQUEST, e.to_string()).into_response()
             }
         }
@@ -110,11 +113,43 @@ pub mod list_blocks {
 /// Takes a contract content address and a byte array key as path parameters,
 /// both encoded as hex.
 pub mod query_state {
+    use std::fmt::Display;
+
+    use serde::Serialize;
+
     use super::*;
+
+    pub const HELP_MSG: &str = r#"
+The query parameters must be empty or one of the following combinations:
+    - block_inclusive
+    - block_exclusive
+    - block_inclusive, solution_inclusive
+    - block_inclusive, solution_exclusive
+"#;
+
+    #[derive(Deserialize, Serialize, Default, Debug)]
+    pub struct QueryStateParams {
+        pub block_inclusive: Option<Word>,
+        pub block_exclusive: Option<Word>,
+        pub solution_inclusive: Option<u64>,
+        pub solution_exclusive: Option<u64>,
+    }
+
+    impl Display for QueryStateParams {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "block_inclusive: {:?}, block_exclusive: {:?}, solution_inclusive: {:?}, solution_exclusive: {:?}",
+                self.block_inclusive, self.block_exclusive, self.solution_inclusive, self.solution_exclusive
+            )
+        }
+    }
+
     pub const PATH: &str = "/query-state/:contract-ca/:key";
     pub async fn handler(
         State(state): State<crate::State>,
         Path((contract_ca, key)): Path<(String, String)>,
+        Query(params): Query<QueryStateParams>,
     ) -> Result<Json<Option<Value>>, Error> {
         let contract_ca: ContentAddress = contract_ca.parse()?;
         let key: Vec<u8> = hex::decode(key)?;
@@ -127,62 +162,8 @@ pub mod query_state {
         // latest state to return. It's possible this query won't make much sense
         // at that point.
 
-        let value = state
-            .conn_pool
-            .query_latest_finalized_block(contract_ca, key)
-            .await?;
-        Ok(Json(value))
-    }
-}
-
-/// The `query-state` get endpoint.
-///
-/// Takes a contract content address and a byte array key as path parameters,
-/// both encoded as hex.
-pub mod query_state_range {
-    use std::fmt::Display;
-
-    use serde::Serialize;
-
-    use super::*;
-
-    pub const HELP_MSG: &str = r#"
-The query range must be one of the following combinations:
-    - block_inclusive
-    - block_exclusive
-    - block_inclusive, solution_inclusive
-    - block_inclusive, solution_exclusive
-"#;
-
-    #[derive(Deserialize, Serialize, Default, Debug)]
-    pub struct QueryStateRange {
-        pub block_inclusive: Option<Word>,
-        pub block_exclusive: Option<Word>,
-        pub solution_inclusive: Option<u64>,
-        pub solution_exclusive: Option<u64>,
-    }
-
-    impl Display for QueryStateRange {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(
-                f,
-                "block_inclusive: {:?}, block_exclusive: {:?}, solution_inclusive: {:?}, solution_exclusive: {:?}",
-                self.block_inclusive, self.block_exclusive, self.solution_inclusive, self.solution_exclusive
-            )
-        }
-    }
-
-    pub const PATH: &str = "/query-state-range/:contract-ca/:key";
-    pub async fn handler(
-        State(state): State<crate::State>,
-        Path((contract_ca, key)): Path<(String, String)>,
-        Query(range): Query<QueryStateRange>,
-    ) -> Result<Json<Option<Value>>, Error> {
-        let contract_ca: ContentAddress = contract_ca.parse()?;
-        let key: Vec<u8> = hex::decode(key)?;
-        let key = key_words_from_bytes(&key);
-        let value = match range {
-            QueryStateRange {
+        let value = match params {
+            QueryStateParams {
                 block_inclusive: Some(block),
                 block_exclusive: None,
                 solution_inclusive: None,
@@ -193,7 +174,7 @@ The query range must be one of the following combinations:
                     .query_state_finalized_inclusive_block(contract_ca, key, block)
                     .await?
             }
-            QueryStateRange {
+            QueryStateParams {
                 block_inclusive: None,
                 block_exclusive: Some(block),
                 solution_inclusive: None,
@@ -204,7 +185,7 @@ The query range must be one of the following combinations:
                     .query_state_finalized_exclusive_block(contract_ca, key, block)
                     .await?
             }
-            QueryStateRange {
+            QueryStateParams {
                 block_inclusive: Some(block),
                 block_exclusive: None,
                 solution_inclusive: Some(solution_ix),
@@ -215,7 +196,7 @@ The query range must be one of the following combinations:
                     .query_state_finalized_inclusive_solution(contract_ca, key, block, solution_ix)
                     .await?
             }
-            QueryStateRange {
+            QueryStateParams {
                 block_inclusive: Some(block),
                 block_exclusive: None,
                 solution_inclusive: None,
@@ -226,7 +207,18 @@ The query range must be one of the following combinations:
                     .query_state_finalized_exclusive_solution(contract_ca, key, block, solution_ix)
                     .await?
             }
-            _ => return Err(Error::InvalidQueryRange(range)),
+            QueryStateParams {
+                block_inclusive: None,
+                block_exclusive: None,
+                solution_inclusive: None,
+                solution_exclusive: None,
+            } => {
+                state
+                    .conn_pool
+                    .query_latest_finalized_block(contract_ca, key)
+                    .await?
+            }
+            _ => return Err(Error::InvalidQueryParameters(params)),
         };
         Ok(Json(value))
     }

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -183,6 +183,7 @@ pub fn with_endpoints(router: Router<State>) -> Router<State> {
         .route(health_check::PATH, get(health_check::handler))
         .route(list_blocks::PATH, get(list_blocks::handler))
         .route(query_state::PATH, get(query_state::handler))
+        .route(query_state_range::PATH, get(query_state_range::handler))
         .route(subscribe_blocks::PATH, get(subscribe_blocks::handler))
 }
 

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -183,7 +183,6 @@ pub fn with_endpoints(router: Router<State>) -> Router<State> {
         .route(health_check::PATH, get(health_check::handler))
         .route(list_blocks::PATH, get(list_blocks::handler))
         .route(query_state::PATH, get(query_state::handler))
-        .route(query_state_range::PATH, get(query_state_range::handler))
         .route(subscribe_blocks::PATH, get(subscribe_blocks::handler))
 }
 

--- a/crates/node-api/tests/endpoints.rs
+++ b/crates/node-api/tests/endpoints.rs
@@ -28,7 +28,7 @@ async fn test_health_check() {
 }
 
 #[tokio::test]
-async fn test_query_state_and_query_state_range() {
+async fn test_query_state() {
     #[cfg(feature = "tracing")]
     init_tracing_subscriber();
 
@@ -69,10 +69,7 @@ async fn test_query_state_and_query_state_range() {
             let response = client()
                 .get(get_url(
                     port,
-                    &format!(
-                        "/query-state-range/{contract}/{key}?block_inclusive={}",
-                        n_blocks
-                    ),
+                    &format!("/query-state/{contract}/{key}?block_inclusive={}", n_blocks),
                 ))
                 .send()
                 .await

--- a/crates/node-db/src/error.rs
+++ b/crates/node-db/src/error.rs
@@ -14,4 +14,7 @@ pub enum QueryError {
     /// A decoding error occurred.
     #[error("failed to decode: {0}")]
     Decode(#[from] DecodeError),
+    /// Unsupported range used in query range.
+    #[error("query range called with an unsupported range")]
+    UnsupportedRange,
 }

--- a/crates/node-db/src/query_range/finalized.rs
+++ b/crates/node-db/src/query_range/finalized.rs
@@ -54,7 +54,7 @@ pub fn query_state_exclusive_block(
 /// solution index (within that block).
 ///
 /// This is inclusive of the solution's state mutations
-/// (..=(block_number, solution_index)).
+/// `..=block_number[..=solution_index]`
 pub fn query_state_inclusive_solution(
     conn: &Connection,
     contract_ca: &ContentAddress,
@@ -83,7 +83,7 @@ pub fn query_state_inclusive_solution(
 /// that was set at or before the given block number and before the
 /// solution index (within that block).
 ///
-/// This is exclusive of the solution's state (..(block_number, solution_index)).
+/// This is exclusive of the solution's state `..=block_number[..solution_index]`.
 pub fn query_state_exclusive_solution(
     conn: &Connection,
     contract_ca: &ContentAddress,

--- a/crates/node/src/state_derivation.rs
+++ b/crates/node/src/state_derivation.rs
@@ -300,6 +300,9 @@ fn map_recoverable_errors(e: InternalError) -> InternalError {
             e @ crate::db::AcquireThenError::Inner(essential_node_db::QueryError::Decode(_)) => {
                 CriticalError::from(e).into()
             }
+            crate::db::AcquireThenError::Inner(essential_node_db::QueryError::UnsupportedRange) => {
+                RecoverableError::Query(essential_node_db::QueryError::UnsupportedRange).into()
+            }
         },
         _ => e,
     }

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -265,6 +265,9 @@ fn map_recoverable_errors(e: InternalError) -> InternalError {
             e @ crate::db::AcquireThenError::Inner(essential_node_db::QueryError::Decode(_)) => {
                 CriticalError::from(e).into()
             }
+            crate::db::AcquireThenError::Inner(essential_node_db::QueryError::UnsupportedRange) => {
+                RecoverableError::Query(essential_node_db::QueryError::UnsupportedRange).into()
+            }
         },
         _ => e,
     }


### PR DESCRIPTION
# Changes
- query-state now uses query_latest_finalized_block to get it's state
- This means state-derivation is no longer required
- query-state-range endpoint for finalized query ranges
- example `/query-state-range/contract_ca/key?block_inclusive=100&solution_exclusive=50`
- query-state-range returns a help message that describes usage

# Motivation
It is very unintuitive for devs to need to pass the `--state-derivation` flag to the builder in order to see any state.It's also a waste to run it in the nodes. State derivation is not super useful atm. See #112 for details.
This updates things so that state derivation is not needed.

# Alternatives
1. We could have kept `query-state` as the `state-derivation` query and added a `query-latest-finalized-state` but that would require explaining lots to new devs that they probably don't care about.
2. We could change the old `query-state` to `query-compacted-state` or something but that doesn't sound very useful.