### PR TITLE
refactor: Move the `node::db` module into `node_db::pool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,6 @@ dependencies = [
  "futures",
  "reqwest",
  "rusqlite",
- "rusqlite-pool",
  "secp256k1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,12 +661,9 @@ dependencies = [
  "essential-state-asm",
  "essential-types",
  "futures",
- "num_cpus",
  "reqwest",
  "rusqlite",
- "rusqlite-pool",
  "secp256k1",
- "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -726,14 +723,18 @@ version = "0.3.0"
 dependencies = [
  "essential-hash",
  "essential-node-db-sql",
+ "essential-node-types",
  "essential-types",
  "futures",
+ "num_cpus",
  "postcard",
  "rusqlite",
  "rusqlite-pool",
  "serde",
+ "tempfile",
  "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/node-api/src/endpoint.rs
+++ b/crates/node-api/src/endpoint.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("failed to decode from hex string: {0}")]
     HexDecode(#[from] hex::FromHexError),
     #[error("DB query failed: {0}")]
-    ConnPoolQuery(#[from] db::AcquireThenQueryError),
+    ConnPoolQuery(#[from] db::pool::AcquireThenQueryError),
     #[error(
         "Invalid query parameter for /query-state: {0}. {}",
         query_state::HELP_MSG

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -76,8 +76,8 @@ pub async fn serve(router: &Router, listener: &TcpListener, conn_limit: usize) {
 /// # async fn main() {
 /// # use essential_node::{self as node};
 /// # use essential_node_api as node_api;
-/// let conf = node::db::Config::default();
-/// let db = node::db(&conf).unwrap();
+/// let conf = node::db::pool::Config::default();
+/// let db = node::db::ConnectionPool::with_tables(&conf).unwrap();
 /// let state = node_api::State {
 ///     conn_pool: db,
 ///     new_block: None,

--- a/crates/node-api/tests/util.rs
+++ b/crates/node-api/tests/util.rs
@@ -1,6 +1,9 @@
 use essential_node::{
     self as node,
-    db::{Config, ConnectionPool, Source},
+    db::{
+        pool::{Config, Source},
+        ConnectionPool,
+    },
 };
 use essential_node_api as node_api;
 use std::future::Future;
@@ -23,7 +26,7 @@ pub fn test_conn_pool() -> ConnectionPool {
         source: Source::Memory(uuid::Uuid::new_v4().into()),
         ..Default::default()
     };
-    node::db(&conf).unwrap()
+    ConnectionPool::with_tables(&conf).unwrap()
 }
 
 pub fn client() -> reqwest::Client {

--- a/crates/node-cli/src/tests.rs
+++ b/crates/node-cli/src/tests.rs
@@ -41,11 +41,11 @@ async fn test_args() {
 async fn test_node() -> (impl std::future::Future<Output = ()>, u16) {
     let block_tx = node::BlockTx::new();
     let block_rx = block_tx.new_listener();
-    let config = node::db::Config {
-        source: node::db::Source::Memory(uuid::Uuid::new_v4().to_string()),
+    let config = node::db::pool::Config {
+        source: node::db::pool::Source::Memory(uuid::Uuid::new_v4().to_string()),
         ..Default::default()
     };
-    let db = node::db(&config).unwrap();
+    let db = node::db::ConnectionPool::with_tables(&config).unwrap();
     let api_state = node_api::State {
         new_block: Some(block_rx),
         conn_pool: db.clone(),

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -13,11 +13,24 @@ essential-hash = { workspace = true }
 essential-node-db-sql = { workspace = true }
 essential-types = { workspace = true }
 futures = { workspace = true }
+num_cpus = { workspace = true, optional = true }
 postcard = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, optional = true }
+rusqlite-pool = { workspace = true, optional = true }
 
 [dev-dependencies]
+essential-node-types = { workspace = true }
 rusqlite-pool = { workspace = true, features = ["tokio"] }
+tempfile = { workspace = true }
 tokio = { workspace = true }
+uuid = { workspace = true }
+
+[features]
+default = ["pool"]
+pool = ["num_cpus", "rusqlite-pool", "rusqlite-pool/tokio", "tokio"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -18,9 +18,7 @@ essential-relayer = { workspace = true }
 essential-state-asm = { workspace = true, optional = true }
 essential-types = { workspace = true }
 futures = { workspace = true }
-num_cpus = { workspace = true }
 rusqlite = { workspace = true }
-rusqlite-pool = { workspace = true, features = ["tokio"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
@@ -34,7 +32,6 @@ essential-sign = { workspace = true }
 essential-state-asm = { workspace = true }
 reqwest = { workspace = true }
 secp256k1 = { workspace = true }
-tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]

--- a/crates/node/src/error.rs
+++ b/crates/node/src/error.rs
@@ -1,5 +1,7 @@
-use crate::db::{AcquireThenQueryError, AcquireThenRusqliteError};
-use essential_node_db::QueryError;
+use crate::db::{
+    pool::{AcquireThenQueryError, AcquireThenRusqliteError},
+    QueryError,
+};
 use essential_types::{predicate, ContentAddress, PredicateAddress};
 use thiserror::Error;
 use tokio::sync::AcquireError;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -8,9 +8,8 @@
 //! - Runs the relayer stream and syncs blocks.
 //! - Performs validation.
 
-use db::ConnectionPool;
-use error::{BigBangError, ConnPoolNewError, CriticalError};
-use essential_node_db as node_db;
+use error::{BigBangError, CriticalError};
+pub use essential_node_db as db;
 use essential_node_types::BigBang;
 use essential_relayer::Relayer;
 use essential_types::ContentAddress;
@@ -19,7 +18,6 @@ pub use validate::validate_dry_run;
 pub use validate::validate_solution_dry_run;
 use validation::validation_stream;
 
-pub mod db;
 mod error;
 mod handles;
 #[cfg(any(feature = "test-utils", test))]
@@ -51,38 +49,6 @@ pub struct RunConfig {
     pub run_validation: bool,
 }
 
-/// Create a new `ConnectionPool` from the given configuration.
-///
-/// Upon construction, the node's database tables are created if they have
-/// not already been created.
-///
-/// ## Example
-///
-/// ```rust
-/// # use essential_node::{BlockTx, db::Config, db, run};
-/// # #[tokio::main]
-/// # async fn main() {
-/// let conf = Config::default();
-/// let db = essential_node::db(&conf).unwrap();
-/// for block in db.list_blocks(0..100).await.unwrap() {
-///     println!("Block: {block:?}");
-/// }
-/// # }
-/// ```
-pub fn db(conf: &db::Config) -> Result<ConnectionPool, ConnPoolNewError> {
-    // Initialize the connection pool.
-    let db = db::ConnectionPool::new(conf)?;
-
-    // Create the tables.
-    let mut conn = db.try_acquire().expect("all permits available");
-    if let db::Source::Path(_) = conf.source {
-        conn.pragma_update(None, "journal_mode", "wal")?;
-    };
-    db::with_tx(&mut conn, |tx| essential_node_db::create_tables(tx))?;
-
-    Ok(db)
-}
-
 /// Ensures that a big bang block exists in the DB for the given `BigBang` configuration.
 ///
 /// If no block exists with `block_number` `0`, this inserts the big bang block.
@@ -95,7 +61,7 @@ pub fn db(conf: &db::Config) -> Result<ConnectionPool, ConnPoolNewError> {
 /// Returns the `ContentAddress` of the big bang `Block`.
 #[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
 pub async fn ensure_big_bang_block(
-    conn_pool: &ConnectionPool,
+    conn_pool: &db::ConnectionPool,
     big_bang: &BigBang,
 ) -> Result<ContentAddress, BigBangError> {
     let bb_block = big_bang.block();
@@ -114,8 +80,8 @@ pub async fn ensure_big_bang_block(
             conn_pool
                 .acquire_then(|conn| {
                     db::with_tx(conn, move |tx| {
-                        node_db::insert_block(tx, &bb_block)?;
-                        node_db::finalize_block(tx, &bbb_ca)?;
+                        db::insert_block(tx, &bb_block)?;
+                        db::finalize_block(tx, &bbb_ca)?;
                         Ok::<_, rusqlite::Error>(())
                     })
                 })
@@ -155,7 +121,7 @@ pub async fn ensure_big_bang_block(
 /// Returns a [`Handle`] that can be used to close the streams.
 /// The streams will continue to run until the handle is dropped.
 pub fn run(
-    conn_pool: ConnectionPool,
+    conn_pool: db::ConnectionPool,
     conf: RunConfig,
     contract_registry: ContentAddress,
     block_notify: BlockTx,
@@ -168,7 +134,7 @@ pub fn run(
     // Run relayer.
     let relayer_handle = if let Some(relayer_source_endpoint) = relayer_source_endpoint {
         let relayer = Relayer::new(relayer_source_endpoint.as_str())?;
-        Some(relayer.run(conn_pool.0.clone(), block_notify.0.clone())?)
+        Some(relayer.run(conn_pool.as_ref().clone(), block_notify.0.clone())?)
     } else {
         None
     };

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -134,7 +134,7 @@ pub fn run(
     // Run relayer.
     let relayer_handle = if let Some(relayer_source_endpoint) = relayer_source_endpoint {
         let relayer = Relayer::new(relayer_source_endpoint.as_str())?;
-        Some(relayer.run(conn_pool.as_ref().clone(), block_notify.0.clone())?)
+        Some(relayer.run(conn_pool.clone(), block_notify.0.clone())?)
     } else {
         None
     };

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -1,10 +1,14 @@
 #![allow(dead_code)]
 
 use crate::{
-    db::{Config, ConnectionPool, Source},
+    db::{
+        finalized::query_state_inclusive_block,
+        get_validation_progress,
+        pool::{Config, Source},
+        ConnectionPool,
+    },
     ensure_big_bang_block,
 };
-use essential_node_db::{finalized::query_state_inclusive_block, get_validation_progress};
 use essential_node_types::{register_contract_solution, BigBang};
 use essential_types::{
     contract::Contract,
@@ -17,7 +21,7 @@ use std::time::Duration;
 
 pub fn test_conn_pool() -> ConnectionPool {
     let conf = test_db_conf();
-    crate::db(&conf).unwrap()
+    ConnectionPool::with_tables(&conf).unwrap()
 }
 
 pub async fn test_conn_pool_with_big_bang() -> ConnectionPool {

--- a/crates/node/src/validate/tests.rs
+++ b/crates/node/src/validate/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    db::with_tx,
+    db::{finalize_block, insert_block, with_tx},
     test_utils::{
         test_block_with_contracts, test_conn_pool, test_conn_pool_with_big_bang,
         test_contract_registry, test_invalid_block, test_invalid_block_with_contract,
@@ -10,7 +10,6 @@ use essential_check::{
     constraint_vm::error::CheckError,
     solution::{PredicateConstraintsError, PredicateError, PredicatesError},
 };
-use essential_node_db::{finalize_block, insert_block};
 use std::time::Duration;
 
 #[tokio::test]

--- a/crates/node/src/validation/tests.rs
+++ b/crates/node/src/validation/tests.rs
@@ -1,9 +1,11 @@
 use super::*;
-use crate::test_utils::{
-    assert_validation_progress_is_some, test_blocks_with_contracts, test_conn_pool_with_big_bang,
-    test_contract_registry, test_invalid_block_with_contract,
+use crate::{
+    db::{self, finalize_block, insert_block},
+    test_utils::{
+        assert_validation_progress_is_some, test_blocks_with_contracts,
+        test_conn_pool_with_big_bang, test_contract_registry, test_invalid_block_with_contract,
+    },
 };
-use essential_node_db::{finalize_block, insert_block};
 use essential_node_types::BigBang;
 use essential_types::{Block, Word};
 use rusqlite::Connection;
@@ -89,7 +91,7 @@ async fn test_invalid_block_validation() {
     // Assert validation progress is still BBB.
     assert_validation_progress_is_some(&conn, &bbb_ca);
     // Assert block is in failed blocks table
-    let fetched_failed_blocks = essential_node_db::list_failed_blocks(&conn, 0..10).unwrap();
+    let fetched_failed_blocks = db::list_failed_blocks(&conn, 0..10).unwrap();
     assert_eq!(fetched_failed_blocks.len(), 1);
     assert_eq!(fetched_failed_blocks[0].0, block.number);
     assert_eq!(
@@ -140,7 +142,7 @@ async fn can_process_valid_and_invalid_blocks() {
     // Assert validation progress is still block 0
     assert_validation_progress_is_some(&conn, &hashes[0]);
     // Assert block is in failed blocks table
-    let fetched_failed_blocks = essential_node_db::list_failed_blocks(&conn, 0..10).unwrap();
+    let fetched_failed_blocks = db::list_failed_blocks(&conn, 0..10).unwrap();
     assert_eq!(fetched_failed_blocks.len(), 1);
     assert_eq!(fetched_failed_blocks[0].0, invalid_block.number);
     assert_eq!(

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -15,7 +15,6 @@ essential-types.workspace = true
 futures.workspace = true
 reqwest = { workspace = true, features = ["json", "stream", "native-tls-alpn"] }
 rusqlite.workspace = true
-rusqlite-pool = { workspace = true, features = ["tokio"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/relayer/src/error.rs
+++ b/crates/relayer/src/error.rs
@@ -1,4 +1,3 @@
-use essential_node_db::QueryError;
 use essential_types::{ContentAddress, Word};
 use thiserror::Error;
 
@@ -26,15 +25,6 @@ pub(crate) type CriticalError = Error;
 /// These causes the relayer to exit a spawned task.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// A DB error occurred.
-    #[error("a DB error occurred: {0}")]
-    Rusqlite(#[from] rusqlite::Error),
-    /// Failed to join the db thread.
-    #[error("an error occurred when joining the db writing thread: {0}")]
-    DbWriteThreadFailed(#[from] tokio::task::JoinError),
-    /// Failed to query the db.
-    #[error("an error occurred when querying the db: {0}")]
-    DbQueryFailed(#[from] QueryError),
     /// Failed to parse a server url.
     #[error("an error occurred when parsing the server url")]
     UrlParse,
@@ -47,9 +37,9 @@ pub enum Error {
     /// An error occurred while building the http client.
     #[error("an error occurred while building the http client: {0}")]
     HttpClientBuild(reqwest::Error),
-    /// The db pool was closed.
-    #[error("failed to acquire a db connection: {0}")]
-    DbPoolClosed(#[from] tokio::sync::AcquireError),
+    /// Failed to acquire then use a DB connection from the pool.
+    #[error("failed to acquire or use a DB connection: {0}")]
+    DbPoolRusqlite(#[from] essential_node_db::pool::AcquireThenRusqliteError),
 }
 
 /// An error that can be recovered from.


### PR DESCRIPTION
Previously, the node's `ConnectionPool` type was defined in the `essential-node` crate's `db` module. This moves the implementation to a feature-gated `pool` module within the `essential-node-db` crate.

This give downstream crates the ability to use the node connection pool abstraction without also needing to include all of the stream stuff from `essential-node`.

Now that the `essential_node::db` module is removed, we instead re-export `essential-node-db` as `essential_node::db`, ensuring users of the node have access to everything they could need from the node DB without having to import the extra crate.

Also updates `essential-relayer` to take advantage of the node's `ConnectionPool` now that it is located in `essential-node-db`.

Closes #74.

Edit: I'll wait for #113 to land then rebase before merging as there might be a couple conflicts.