### PR TITLE
feat: add solution_data table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,6 @@ dependencies = [
  "essential-types",
  "futures",
  "num_cpus",
- "postcard",
  "rusqlite",
  "rusqlite-pool",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ http = "1.1.0"
 hyper = "1.3.1"
 hyper-util = "0.1.7"
 num_cpus = "1.16"
-postcard = { version = "1.0.8", features = ["alloc"] }
 reqwest = { version = "0.12.5", features = ["json", "stream"] }
 rusqlite = "0.32"
 secp256k1 = { version = "0.30", features = ["rand", "std", "hashes"] }

--- a/crates/node-db-sql/sql/create/dec_var.sql
+++ b/crates/node-db-sql/sql/create/dec_var.sql
@@ -1,7 +1,9 @@
 CREATE TABLE IF NOT EXISTS dec_var (
     id INTEGER PRIMARY KEY,
     solution_id INTEGER NOT NULL,
-    data_index INTEGER NOT NULL,
+    data_id INTEGER NOT NULL,
     dec_var_index INTEGER NOT NULL,
-    value BLOB NOT NULL
+    value BLOB NOT NULL,
+    FOREIGN KEY (solution_id) REFERENCES solution (id),
+    FOREIGN KEY (data_id) REFERENCES solution_data (id)
 );

--- a/crates/node-db-sql/sql/create/dec_var.sql
+++ b/crates/node-db-sql/sql/create/dec_var.sql
@@ -1,9 +1,7 @@
 CREATE TABLE IF NOT EXISTS dec_var (
     id INTEGER PRIMARY KEY,
-    solution_id INTEGER NOT NULL,
     data_id INTEGER NOT NULL,
     dec_var_index INTEGER NOT NULL,
     value BLOB NOT NULL,
-    FOREIGN KEY (solution_id) REFERENCES solution (id),
     FOREIGN KEY (data_id) REFERENCES solution_data (id)
 );

--- a/crates/node-db-sql/sql/create/mutation.sql
+++ b/crates/node-db-sql/sql/create/mutation.sql
@@ -1,9 +1,10 @@
 CREATE TABLE IF NOT EXISTS mutation (
     id INTEGER PRIMARY KEY,
     solution_id INTEGER NOT NULL,
-    data_index INTEGER NOT NULL,
+    data_id INTEGER NOT NULL,
     mutation_index INTEGER NOT NULL,
-    contract_ca BLOB NOT NULL,
     key BLOB NOT NULL,
-    value BLOB NOT NULL
+    value BLOB NOT NULL,
+    FOREIGN KEY (solution_id) REFERENCES solution (id),
+    FOREIGN KEY (data_id) REFERENCES solution_data (id)
 );

--- a/crates/node-db-sql/sql/create/mutation.sql
+++ b/crates/node-db-sql/sql/create/mutation.sql
@@ -1,10 +1,8 @@
 CREATE TABLE IF NOT EXISTS mutation (
     id INTEGER PRIMARY KEY,
-    solution_id INTEGER NOT NULL,
     data_id INTEGER NOT NULL,
     mutation_index INTEGER NOT NULL,
     key BLOB NOT NULL,
     value BLOB NOT NULL,
-    FOREIGN KEY (solution_id) REFERENCES solution (id),
     FOREIGN KEY (data_id) REFERENCES solution_data (id)
 );

--- a/crates/node-db-sql/sql/create/solution.sql
+++ b/crates/node-db-sql/sql/create/solution.sql
@@ -1,5 +1,4 @@
 CREATE TABLE IF NOT EXISTS solution (
     id INTEGER PRIMARY KEY,
-    content_hash BLOB NOT NULL UNIQUE,
-    solution BLOB NOT NULL
+    content_hash BLOB NOT NULL UNIQUE
 );

--- a/crates/node-db-sql/sql/create/solution_data.sql
+++ b/crates/node-db-sql/sql/create/solution_data.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS solution_data (
+    id INTEGER PRIMARY KEY,
+    solution_id INTEGER NOT NULL,
+    data_index INTEGER NOT NULL,
+    contract_addr BLOB NOT NULL,
+    predicate_addr BLOB NOT NULL,
+    FOREIGN KEY (solution_id) REFERENCES solution (id)
+);

--- a/crates/node-db-sql/sql/create/solution_data.sql
+++ b/crates/node-db-sql/sql/create/solution_data.sql
@@ -5,4 +5,5 @@ CREATE TABLE IF NOT EXISTS solution_data (
     contract_addr BLOB NOT NULL,
     predicate_addr BLOB NOT NULL,
     FOREIGN KEY (solution_id) REFERENCES solution (id)
+    UNIQUE (solution_id, data_index)
 );

--- a/crates/node-db-sql/sql/insert/dec_var.sql
+++ b/crates/node-db-sql/sql/insert/dec_var.sql
@@ -1,23 +1,12 @@
 INSERT
     OR IGNORE INTO dec_var (
-        solution_id,
         data_id,
         dec_var_index,
         value
     )
 VALUES
     (
-        (
-            SELECT
-                id
-            FROM
-                solution
-            WHERE
-                content_hash = :solution_hash
-            LIMIT
-                1
-        ),
-        (
+       (
             SELECT
                 solution_data.id
             FROM

--- a/crates/node-db-sql/sql/insert/dec_var.sql
+++ b/crates/node-db-sql/sql/insert/dec_var.sql
@@ -19,11 +19,12 @@ VALUES
         ),
         (
             SELECT
-                id
+                solution_data.id
             FROM
                 solution_data
+                JOIN solution ON solution.id = solution_data.solution_id
             WHERE
-                data_index = :data_index
+                solution.content_hash = :solution_hash AND solution_data.data_index = :data_index
             LIMIT
                 1
         ), :dec_var_index, :value

--- a/crates/node-db-sql/sql/insert/dec_var.sql
+++ b/crates/node-db-sql/sql/insert/dec_var.sql
@@ -1,7 +1,7 @@
 INSERT
     OR IGNORE INTO dec_var (
         solution_id,
-        data_index,
+        data_id,
         dec_var_index,
         value
     )
@@ -16,5 +16,15 @@ VALUES
                 content_hash = :solution_hash
             LIMIT
                 1
-        ), :data_index, :dec_var_index, :value
+        ),
+        (
+            SELECT
+                id
+            FROM
+                solution_data
+            WHERE
+                data_index = :data_index
+            LIMIT
+                1
+        ), :dec_var_index, :value
     );

--- a/crates/node-db-sql/sql/insert/mutation.sql
+++ b/crates/node-db-sql/sql/insert/mutation.sql
@@ -19,12 +19,13 @@ VALUES
                 1
         ), 
         (
-            SELECT 
-                id
+            SELECT
+                solution_data.id
             FROM
                 solution_data
+                JOIN solution ON solution.id = solution_data.solution_id
             WHERE
-                data_index = :data_index
+                solution.content_hash = :solution_hash AND solution_data.data_index = :data_index
             LIMIT
                 1
         ), :mutation_index, :key, :value

--- a/crates/node-db-sql/sql/insert/mutation.sql
+++ b/crates/node-db-sql/sql/insert/mutation.sql
@@ -1,9 +1,8 @@
 INSERT
     OR IGNORE INTO mutation (
         solution_id,
-        data_index,
+        data_id,
         mutation_index,
-        contract_ca,
         key,
         value
     )
@@ -18,5 +17,15 @@ VALUES
                 content_hash = :solution_hash
             LIMIT
                 1
-        ), :data_index, :mutation_index, :contract_ca, :key, :value
+        ), 
+        (
+            SELECT 
+                id
+            FROM
+                solution_data
+            WHERE
+                data_index = :data_index
+            LIMIT
+                1
+        ), :mutation_index, :key, :value
     );

--- a/crates/node-db-sql/sql/insert/mutation.sql
+++ b/crates/node-db-sql/sql/insert/mutation.sql
@@ -1,6 +1,5 @@
 INSERT
     OR IGNORE INTO mutation (
-        solution_id,
         data_id,
         mutation_index,
         key,
@@ -8,17 +7,7 @@ INSERT
     )
 VALUES
     (
-        (
-            SELECT
-                id
-            FROM
-                solution
-            WHERE
-                content_hash = :solution_hash
-            LIMIT
-                1
-        ), 
-        (
+       (
             SELECT
                 solution_data.id
             FROM

--- a/crates/node-db-sql/sql/insert/solution.sql
+++ b/crates/node-db-sql/sql/insert/solution.sql
@@ -1,4 +1,4 @@
 INSERT
-    OR IGNORE INTO solution (content_hash, solution)
+    OR IGNORE INTO solution (content_hash)
 VALUES
-    (:content_hash, :solution)
+    (:content_hash)

--- a/crates/node-db-sql/sql/insert/solution_data.sql
+++ b/crates/node-db-sql/sql/insert/solution_data.sql
@@ -1,0 +1,15 @@
+INSERT
+    OR IGNORE INTO solution_data (solution_id, data_index, contract_addr, predicate_addr)
+VALUES
+    (
+        (
+            SELECT
+                id
+            FROM
+                solution
+            WHERE
+                content_hash = :solution_hash
+            LIMIT
+                1
+        ), :data_index, :contract_addr, :predicate_addr
+    )

--- a/crates/node-db-sql/sql/query/get_block.sql
+++ b/crates/node-db-sql/sql/query/get_block.sql
@@ -9,3 +9,5 @@ FROM
     LEFT JOIN solution ON block_solution.solution_id = solution.id
 WHERE
     block.block_address = :block_address
+ORDER BY
+    block_solution.solution_index ASC

--- a/crates/node-db-sql/sql/query/get_block.sql
+++ b/crates/node-db-sql/sql/query/get_block.sql
@@ -2,7 +2,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution.solution
+    solution.content_hash
 FROM
     block
     LEFT JOIN block_solution ON block.id = block_solution.block_id

--- a/crates/node-db-sql/sql/query/get_solution.sql
+++ b/crates/node-db-sql/sql/query/get_solution.sql
@@ -1,6 +1,0 @@
-SELECT
-    solution
-FROM
-    solution
-WHERE
-    content_hash = ?

--- a/crates/node-db-sql/sql/query/get_solution_data.sql
+++ b/crates/node-db-sql/sql/query/get_solution_data.sql
@@ -1,9 +1,10 @@
 SELECT
-    solution_data.data_index,
     solution_data.contract_addr,
     solution_data.predicate_addr
 FROM
     solution
     JOIN solution_data ON solution_data.solution_id = solution.id
 WHERE
-    solution.content_hash = ?;
+    solution.content_hash = ?
+ORDER BY
+    solution_data.data_index ASC;

--- a/crates/node-db-sql/sql/query/get_solution_data.sql
+++ b/crates/node-db-sql/sql/query/get_solution_data.sql
@@ -1,0 +1,9 @@
+SELECT
+    solution_data.data_index,
+    solution_data.contract_addr,
+    solution_data.predicate_addr
+FROM
+    solution
+    JOIN solution_data ON solution_data.solution_id = solution.id
+WHERE
+    solution.content_hash = ?;

--- a/crates/node-db-sql/sql/query/get_solution_dec_vars.sql
+++ b/crates/node-db-sql/sql/query/get_solution_dec_vars.sql
@@ -1,9 +1,8 @@
 SELECT
-    dec_var.dec_var_index,
     dec_var.value
 FROM
     solution
     JOIN solution_data ON solution_data.solution_id = solution.id
-    JOIN dec_var ON dec_var.solution_id = solution.id AND dec_var.data_id = solution_data.id
+    JOIN dec_var ON dec_var.data_id = solution_data.id
 WHERE
     solution.content_hash = :content_hash AND solution_data.data_index = :data_index;

--- a/crates/node-db-sql/sql/query/get_solution_dec_vars.sql
+++ b/crates/node-db-sql/sql/query/get_solution_dec_vars.sql
@@ -1,0 +1,9 @@
+SELECT
+    dec_var.dec_var_index,
+    dec_var.value
+FROM
+    solution
+    JOIN solution_data ON solution_data.solution_id = solution.id
+    JOIN dec_var ON dec_var.solution_id = solution.id AND dec_var.data_id = solution_data.id
+WHERE
+    solution.content_hash = :content_hash AND solution_data.data_index = :data_index;

--- a/crates/node-db-sql/sql/query/get_solution_dec_vars.sql
+++ b/crates/node-db-sql/sql/query/get_solution_dec_vars.sql
@@ -6,3 +6,5 @@ FROM
     JOIN dec_var ON dec_var.data_id = solution_data.id
 WHERE
     solution.content_hash = :content_hash AND solution_data.data_index = :data_index;
+ORDER BY
+    dec_var.dec_var_index ASC

--- a/crates/node-db-sql/sql/query/get_solution_mutations.sql
+++ b/crates/node-db-sql/sql/query/get_solution_mutations.sql
@@ -1,0 +1,10 @@
+SELECT
+    mutation.mutation_index,
+    mutation.key,
+    mutation.value
+FROM
+    solution
+    JOIN solution_data ON solution_data.solution_id = solution.id
+    JOIN mutation ON mutation.solution_id = solution.id AND mutation.data_id = solution_data.id
+WHERE
+    solution.content_hash = :content_hash AND solution_data.data_index = :data_index;

--- a/crates/node-db-sql/sql/query/get_solution_mutations.sql
+++ b/crates/node-db-sql/sql/query/get_solution_mutations.sql
@@ -7,3 +7,5 @@ FROM
     JOIN mutation ON mutation.data_id = solution_data.id
 WHERE
     solution.content_hash = :content_hash AND solution_data.data_index = :data_index;
+ORDER BY
+    mutation.mutation_index ASC

--- a/crates/node-db-sql/sql/query/get_solution_mutations.sql
+++ b/crates/node-db-sql/sql/query/get_solution_mutations.sql
@@ -1,10 +1,9 @@
 SELECT
-    mutation.mutation_index,
     mutation.key,
     mutation.value
 FROM
     solution
     JOIN solution_data ON solution_data.solution_id = solution.id
-    JOIN mutation ON mutation.solution_id = solution.id AND mutation.data_id = solution_data.id
+    JOIN mutation ON mutation.data_id = solution_data.id
 WHERE
     solution.content_hash = :content_hash AND solution_data.data_index = :data_index;

--- a/crates/node-db-sql/sql/query/list_blocks.sql
+++ b/crates/node-db-sql/sql/query/list_blocks.sql
@@ -3,7 +3,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution.solution
+    solution.content_hash
 FROM
     block
     LEFT JOIN block_solution ON block.id = block_solution.block_id

--- a/crates/node-db-sql/sql/query/list_blocks_by_time.sql
+++ b/crates/node-db-sql/sql/query/list_blocks_by_time.sql
@@ -3,7 +3,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution.solution
+    solution.content_hash
 
 FROM
     block

--- a/crates/node-db-sql/sql/query/list_unchecked_blocks.sql
+++ b/crates/node-db-sql/sql/query/list_unchecked_blocks.sql
@@ -3,7 +3,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution.solution
+    solution.content_hash
 FROM
     block
     LEFT JOIN block_solution ON block.id = block_solution.block_id

--- a/crates/node-db-sql/sql/query/query_state_at_block_finalized.sql
+++ b/crates/node-db-sql/sql/query/query_state_at_block_finalized.sql
@@ -2,10 +2,11 @@ SELECT
     mutation.value
 FROM
     mutation
+    JOIN solution_data ON solution_data.id = mutation.data_id
     JOIN block_solution ON block_solution.solution_id = mutation.solution_id
     JOIN finalized_block ON finalized_block.block_id = block_solution.block_id
 WHERE
-    mutation.contract_ca = :contract_ca
+    solution_data.contract_addr = :contract_ca
     AND mutation.key = :key
     AND finalized_block.block_number <= :block_number
 ORDER BY

--- a/crates/node-db-sql/sql/query/query_state_at_block_finalized.sql
+++ b/crates/node-db-sql/sql/query/query_state_at_block_finalized.sql
@@ -3,7 +3,7 @@ SELECT
 FROM
     mutation
     JOIN solution_data ON solution_data.id = mutation.data_id
-    JOIN block_solution ON block_solution.solution_id = mutation.solution_id
+    JOIN block_solution ON block_solution.solution_id = solution_data.solution_id
     JOIN finalized_block ON finalized_block.block_id = block_solution.block_id
 WHERE
     solution_data.contract_addr = :contract_ca

--- a/crates/node-db-sql/sql/query/query_state_at_solution_finalized.sql
+++ b/crates/node-db-sql/sql/query/query_state_at_solution_finalized.sql
@@ -3,7 +3,7 @@ SELECT
 FROM
     mutation
     JOIN solution_data ON solution_data.id = mutation.data_id
-    JOIN block_solution ON block_solution.solution_id = mutation.solution_id
+    JOIN block_solution ON block_solution.solution_id = solution_data.solution_id
     JOIN finalized_block ON finalized_block.block_id = block_solution.block_id
 WHERE
     solution_data.contract_addr = :contract_ca

--- a/crates/node-db-sql/sql/query/query_state_at_solution_finalized.sql
+++ b/crates/node-db-sql/sql/query/query_state_at_solution_finalized.sql
@@ -2,10 +2,11 @@ SELECT
     mutation.value
 FROM
     mutation
+    JOIN solution_data ON solution_data.id = mutation.data_id
     JOIN block_solution ON block_solution.solution_id = mutation.solution_id
     JOIN finalized_block ON finalized_block.block_id = block_solution.block_id
 WHERE
-    mutation.contract_ca = :contract_ca
+    solution_data.contract_addr = :contract_ca
     AND mutation.key = :key
     AND (
         finalized_block.block_number,

--- a/crates/node-db-sql/src/lib.rs
+++ b/crates/node-db-sql/src/lib.rs
@@ -25,6 +25,7 @@ pub mod create {
     decl_const_sql_str!(FAILED_BLOCK, "create/failed_block.sql");
     decl_const_sql_str!(FINALIZED_BLOCK, "create/finalized_block.sql");
     decl_const_sql_str!(MUTATION, "create/mutation.sql");
+    decl_const_sql_str!(SOLUTION_DATA, "create/solution_data.sql");
     decl_const_sql_str!(SOLUTION, "create/solution.sql");
     decl_const_sql_str!(STATE, "create/state.sql");
     decl_const_sql_str!(VALIDATION_PROGRESS, "create/validation_progress.sql");
@@ -38,6 +39,7 @@ pub mod insert {
     decl_const_sql_str!(FAILED_BLOCK, "insert/failed_block.sql");
     decl_const_sql_str!(FINALIZE_BLOCK, "insert/finalize_block.sql");
     decl_const_sql_str!(MUTATION, "insert/mutation.sql");
+    decl_const_sql_str!(SOLUTION_DATA, "insert/solution_data.sql");
     decl_const_sql_str!(SOLUTION, "insert/solution.sql");
     decl_const_sql_str!(VALIDATION_PROGRESS, "insert/validation_progress.sql");
 }
@@ -59,7 +61,9 @@ pub mod query {
         GET_PARENT_BLOCK_ADDRESS,
         "query/get_parent_block_address.sql"
     );
-    decl_const_sql_str!(GET_SOLUTION, "query/get_solution.sql");
+    decl_const_sql_str!(GET_SOLUTION_DATA, "query/get_solution_data.sql");
+    decl_const_sql_str!(GET_SOLUTION_DEC_VARS, "query/get_solution_dec_vars.sql");
+    decl_const_sql_str!(GET_SOLUTION_MUTATIONS, "query/get_solution_mutations.sql");
     decl_const_sql_str!(GET_STATE, "query/get_state.sql");
     decl_const_sql_str!(GET_VALIDATION_PROGRESS, "query/get_validation_progress.sql");
     decl_const_sql_str!(LIST_BLOCKS, "query/list_blocks.sql");
@@ -110,6 +114,7 @@ pub mod table {
     pub const FAILED_BLOCK: Table = Table::new("failed_block", create::FAILED_BLOCK);
     pub const FINALIZED_BLOCK: Table = Table::new("finalized_block", create::FINALIZED_BLOCK);
     pub const MUTATION: Table = Table::new("mutation", create::MUTATION);
+    pub const SOLUTION_DATA: Table = Table::new("solution_data", create::SOLUTION_DATA);
     pub const SOLUTION: Table = Table::new("solution", create::SOLUTION);
     pub const STATE: Table = Table::new("state", create::STATE);
     pub const VALIDATION_PROGRESS: Table =
@@ -121,6 +126,7 @@ pub mod table {
         DEC_VAR,
         FINALIZED_BLOCK,
         MUTATION,
+        SOLUTION_DATA,
         SOLUTION,
         BLOCK_SOLUTION,
         FAILED_BLOCK,

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -15,7 +15,6 @@ essential-node-types = { workspace = true, optional = true, features = ["block-n
 essential-types = { workspace = true }
 futures = { workspace = true }
 num_cpus = { workspace = true, optional = true }
-postcard = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/node-db/src/error.rs
+++ b/crates/node-db/src/error.rs
@@ -1,19 +1,11 @@
 use thiserror::Error;
 
-/// Any error that might occur during decoding of a type returned by the DB.
-#[derive(Debug, Error)]
-#[error("decoding failed due to postcard deserialization error: {0}")]
-pub struct DecodeError(#[from] pub postcard::Error);
-
 /// A database or decoding error returned by a query.
 #[derive(Debug, Error)]
 pub enum QueryError {
     /// A DB error occurred.
     #[error("a DB error occurred: {0}")]
     Rusqlite(#[from] rusqlite::Error),
-    /// A decoding error occurred.
-    #[error("failed to decode: {0}")]
-    Decode(#[from] DecodeError),
     /// Unsupported range used in query range.
     #[error("query range called with an unsupported range")]
     UnsupportedRange,

--- a/crates/node-db/src/lib.rs
+++ b/crates/node-db/src/lib.rs
@@ -248,6 +248,7 @@ pub fn get_solution(tx: &Transaction, ca: &ContentAddress) -> Result<Solution, Q
     let mut data_stmt = tx.prepare(sql::query::GET_SOLUTION_DATA)?;
     let mut data = data_stmt
         .query_map([ca.0], |row| {
+            let index = row.get::<_, i64>("data_index")? as usize;
             let contract_addr = row.get::<_, Hash>("contract_addr")?;
             let predicate_addr = row.get::<_, Hash>("predicate_addr")?;
             Ok(SolutionData {

--- a/crates/node-db/src/lib.rs
+++ b/crates/node-db/src/lib.rs
@@ -475,7 +475,7 @@ pub fn list_blocks(tx: &Transaction, block_range: Range<Word>) -> Result<Vec<Blo
         // Add the solution.
         // If there are performance issues, use statements in `get_solution` directly.
         // See https://github.com/essential-contributions/essential-node/issues/154.
-       let solution = get_solution(tx, &solution_addr)?;
+        let solution = get_solution(tx, &solution_addr)?;
         block.solutions.push(solution);
     }
     Ok(blocks)

--- a/crates/node-db/src/lib.rs
+++ b/crates/node-db/src/lib.rs
@@ -354,6 +354,8 @@ pub fn get_block(
         }
         let mut block = block_in_progress.expect("should have been set above at worst case");
         // Add the solution.
+        // If there are performance issues, use statements in `get_solution` directly.
+        // See https://github.com/essential-contributions/essential-node/issues/154.
         let solution = get_solution(tx, &solution_addr)?;
         block.solutions.push(solution);
         block_in_progress = Some(block);
@@ -471,7 +473,9 @@ pub fn list_blocks(tx: &Transaction, block_range: Range<Word>) -> Result<Vec<Blo
         };
 
         // Add the solution.
-        let solution = get_solution(tx, &solution_addr)?;
+        // If there are performance issues, use statements in `get_solution` directly.
+        // See https://github.com/essential-contributions/essential-node/issues/154.
+       let solution = get_solution(tx, &solution_addr)?;
         block.solutions.push(solution);
     }
     Ok(blocks)
@@ -536,6 +540,8 @@ pub fn list_blocks_by_time(
         };
 
         // Add the solution.
+        // If there are performance issues, use statements in `get_solution` directly.
+        // See https://github.com/essential-contributions/essential-node/issues/154.
         let solution = get_solution(tx, &solution_addr)?;
         block.solutions.push(solution);
     }
@@ -621,6 +627,8 @@ pub fn list_unchecked_blocks(
         };
 
         // Add the solution.
+        // If there are performance issues, use statements in `get_solution` directly.
+        // See https://github.com/essential-contributions/essential-node/issues/154.
         let solution = get_solution(tx, &solution_addr)?;
         block.solutions.push(solution);
     }

--- a/crates/node-db/src/lib.rs
+++ b/crates/node-db/src/lib.rs
@@ -11,7 +11,7 @@
 //! functions required for safely creating the necessary tables and inserting/
 //! querying/updating them as necessary.
 
-pub use error::{DecodeError, QueryError};
+pub use error::QueryError;
 use essential_hash::content_addr;
 #[doc(inline)]
 pub use essential_node_db_sql as sql;
@@ -26,7 +26,6 @@ pub use pool::ConnectionPool;
 pub use query_range::address;
 pub use query_range::finalized;
 use rusqlite::{named_params, params, Connection, OptionalExtension, Transaction};
-use serde::{Deserialize, Serialize};
 use std::{ops::Range, time::Duration};
 
 mod error;
@@ -54,26 +53,6 @@ pub trait AwaitNewBlock {
     /// `None` when the notification source is no longer available.
     #[allow(async_fn_in_trait)]
     async fn await_new_block(&mut self) -> Option<()>;
-}
-
-/// Encodes the given value into a blob.
-///
-/// This serializes the value using postcard.
-pub fn encode<T>(value: &T) -> Vec<u8>
-where
-    T: Serialize,
-{
-    postcard::to_allocvec(value).expect("postcard serialization cannot fail")
-}
-
-/// Decodes the given blob into a value of type `T`.
-///
-/// This deserializes the bytes into a value of `T` with `postcard`.
-pub fn decode<T>(value: &[u8]) -> Result<T, DecodeError>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    Ok(postcard::from_bytes(value)?)
 }
 
 /// Create all tables.

--- a/crates/node-db/src/pool.rs
+++ b/crates/node-db/src/pool.rs
@@ -205,11 +205,8 @@ impl ConnectionPool {
         &self,
         block_address: ContentAddress,
     ) -> Result<Option<Block>, AcquireThenQueryError> {
-        self.acquire_then(move |h| {
-            let tx = h.transaction()?;
-            crate::get_block(&tx, &block_address)
-        })
-        .await
+        self.acquire_then(move |h| with_tx(h, |tx| crate::get_block(tx, &block_address)))
+            .await
     }
 
     /// Fetches a solution by its content address.
@@ -217,11 +214,8 @@ impl ConnectionPool {
         &self,
         ca: ContentAddress,
     ) -> Result<Solution, AcquireThenQueryError> {
-        self.acquire_then(move |h| {
-            let tx = h.transaction()?;
-            crate::get_solution(&tx, &ca)
-        })
-        .await
+        self.acquire_then(move |h| with_tx(h, |tx| crate::get_solution(tx, &ca)))
+            .await
     }
 
     /// Fetches the state value for the given contract content address and key pair.
@@ -358,7 +352,7 @@ impl ConnectionPool {
         &self,
         block_range: Range<Word>,
     ) -> Result<Vec<Block>, AcquireThenQueryError> {
-        self.acquire_then(move |h| crate::list_blocks(h, block_range))
+        self.acquire_then(move |h| with_tx(h, |tx| crate::list_blocks(tx, block_range)))
             .await
     }
 
@@ -369,8 +363,12 @@ impl ConnectionPool {
         page_size: i64,
         page_number: i64,
     ) -> Result<Vec<Block>, AcquireThenQueryError> {
-        self.acquire_then(move |h| crate::list_blocks_by_time(h, range, page_size, page_number))
-            .await
+        self.acquire_then(move |h| {
+            with_tx(h, |tx| {
+                crate::list_blocks_by_time(tx, range, page_size, page_number)
+            })
+        })
+        .await
     }
 
     /// Subscribe to all blocks from the given starting block number.
@@ -426,6 +424,12 @@ impl AsRef<rusqlite::Connection> for ConnectionHandle {
     }
 }
 
+impl AsMut<rusqlite::Connection> for ConnectionHandle {
+    fn as_mut(&mut self) -> &mut rusqlite::Connection {
+        self
+    }
+}
+
 impl core::ops::Deref for ConnectionHandle {
     type Target = AsyncConnectionHandle;
     fn deref(&self) -> &Self::Target {
@@ -440,7 +444,7 @@ impl core::ops::DerefMut for ConnectionHandle {
 }
 
 impl AcquireConnection for ConnectionPool {
-    async fn acquire_connection(&self) -> Option<impl 'static + AsRef<rusqlite::Connection>> {
+    async fn acquire_connection(&self) -> Option<impl 'static + AsMut<rusqlite::Connection>> {
         self.acquire().await.ok()
     }
 }

--- a/crates/node-db/src/pool.rs
+++ b/crates/node-db/src/pool.rs
@@ -205,17 +205,23 @@ impl ConnectionPool {
         &self,
         block_address: ContentAddress,
     ) -> Result<Option<Block>, AcquireThenQueryError> {
-        self.acquire_then(move |h| crate::get_block(h, &block_address))
-            .await
+        self.acquire_then(move |h| {
+            let tx = h.transaction()?;
+            crate::get_block(&tx, &block_address)
+        })
+        .await
     }
 
     /// Fetches a solution by its content address.
     pub async fn get_solution(
         &self,
         ca: ContentAddress,
-    ) -> Result<Option<Solution>, AcquireThenQueryError> {
-        self.acquire_then(move |h| crate::get_solution(h, &ca))
-            .await
+    ) -> Result<Solution, AcquireThenQueryError> {
+        self.acquire_then(move |h| {
+            let tx = h.transaction()?;
+            crate::get_solution(&tx, &ca)
+        })
+        .await
     }
 
     /// Fetches the state value for the given contract content address and key pair.

--- a/crates/node-db/src/query_range/finalized.rs
+++ b/crates/node-db/src/query_range/finalized.rs
@@ -1,11 +1,10 @@
 //! Finalized queries query for the most recent version of a key less than or equal to a
 //! given block number or solution index for blocks that have been finalized.
 
+use crate::{blob_from_words, words_from_blob, QueryError};
 use essential_node_db_sql as sql;
 use essential_types::{ContentAddress, Key, Value, Word};
 use rusqlite::{named_params, Connection, OptionalExtension};
-
-use crate::{blob_from_words, words_from_blob, QueryError};
 
 /// Query the most recent value for a key in a contract's state
 /// that was set at or before the given block number.

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -53,7 +53,7 @@ fn test_insert_block() {
 
             for (data_ix, data) in solution.data.iter().enumerate() {
                 // Verify solution data was inserted corectly
-                let query = "SELECT solution_data.contract_addr, solution_data.predicate_addr 
+                let query = "SELECT solution_data.contract_addr, solution_data.predicate_addr
                     FROM solution_data JOIN solution ON solution_data.solution_id = solution.id
                     WHERE solution.content_hash = ? AND solution_data.data_index = ?";
                 let mut stmt = conn.prepare(query).unwrap();
@@ -75,8 +75,8 @@ fn test_insert_block() {
                 for (mutation_ix, mutation) in data.state_mutations.iter().enumerate() {
                     // Query deployed contract
                     let query = "SELECT mutation.key FROM mutation
-                    JOIN solution ON mutation.solution_id = solution.id
                     JOIN solution_data ON solution_data.id = mutation.data_id
+                    JOIN solution ON solution_data.solution_id = solution.id
                     WHERE solution.content_hash = ? AND mutation.mutation_index = ? AND solution_data.data_index = ?
                     ORDER BY mutation.mutation_index ASC";
                     let mut stmt = conn.prepare(query).unwrap();
@@ -94,8 +94,9 @@ fn test_insert_block() {
                 // Verify dec vars were inserted correctly
                 for (dvi, dec_var) in data.decision_variables.iter().enumerate() {
                     // Query dec vars
-                    let query = "SELECT dec_var.value
-                        FROM dec_var JOIN solution ON dec_var.solution_id = solution.id JOIN solution_data ON dec_var.data_id = solution_data.id
+                    let query = "SELECT dec_var.value FROM dec_var
+                        JOIN solution_data ON solution_data.id = dec_var.data_id
+                        JOIN solution ON solution_data.solution_id = solution.id
                         WHERE solution_data.data_index = ? AND dec_var.dec_var_index = ? AND solution.content_hash = ?";
                     let mut stmt = conn.prepare(query).unwrap();
                     let mut dec_var_result = stmt

--- a/crates/node-db/tests/query.rs
+++ b/crates/node-db/tests/query.rs
@@ -18,12 +18,11 @@ fn test_get_solution() {
     let tx = conn.transaction().unwrap();
     node_db::create_tables(&tx).unwrap();
     node_db::insert_block(&tx, &block).unwrap();
-    tx.commit().unwrap();
 
     // Fetch the first solution.
     let solution = &block.solutions[0];
     let sol_ca = essential_hash::content_addr(solution);
-    let fetched_solution = node_db::get_solution(&conn, &sol_ca).unwrap().unwrap();
+    let fetched_solution = node_db::get_solution(&tx, &sol_ca).unwrap();
 
     assert_eq!(solution, &fetched_solution);
 }

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -180,7 +180,8 @@ async fn get_next_block(
             Ok(Err(CriticalError::Fork.into()))
         } else {
             let block_address = blocks.into_iter().next().expect("blocks is not empty");
-            let block = essential_node_db::get_block(conn, &block_address)?;
+            let tx = conn.transaction()?;
+            let block = essential_node_db::get_block(&tx, &block_address)?;
             Ok(Ok(block))
         }
     })

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -144,12 +144,10 @@ async fn validate_next_block(
                     .get(solution_index)
                     .expect("Failed solution must exist."),
             );
-            let mut conn = conn_pool.acquire().await.map_err(CriticalError::from)?;
+            let conn = conn_pool.acquire().await.map_err(CriticalError::from)?;
             tokio::task::spawn_blocking(move || {
                 db::insert_failed_block(&conn, &block_address, &failed_solution)
                     .map_err(ValidationError::from)?;
-                let tx = conn.transaction().unwrap();
-                tx.commit().unwrap();
                 Ok(false)
             })
             .await

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -235,9 +235,6 @@ fn map_recoverable_errors(e: InternalError) -> InternalError {
                     CriticalError::DatabaseFailed(rus).into()
                 }
             }
-            e @ db::pool::AcquireThenError::Inner(db::QueryError::Decode(_)) => {
-                CriticalError::from(e).into()
-            }
             db::pool::AcquireThenError::Inner(essential_node_db::QueryError::UnsupportedRange) => {
                 RecoverableError::Query(essential_node_db::QueryError::UnsupportedRange).into()
             }

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -70,7 +70,7 @@ async fn test_run() {
 
     // Check block, state and validation progress
     let mut conn = db.acquire().await.unwrap();
-    assert_submit_solutions_effects(&mut *conn, vec![test_blocks[0].clone()]);
+    assert_submit_solutions_effects(&mut conn, vec![test_blocks[0].clone()]);
 
     // Insert block 1 and 2 to database and send notification
     node_server
@@ -90,7 +90,7 @@ async fn test_run() {
     // Check block, state and validation progress
     let mut conn = db.acquire().await.unwrap();
     assert_submit_solutions_effects(
-        &mut *conn,
+        &mut conn,
         vec![test_blocks[1].clone(), test_blocks[2].clone()],
     );
 
@@ -105,7 +105,7 @@ async fn test_run() {
 
     // Check block, state and validation progress
     let mut conn = db.acquire().await.unwrap();
-    assert_submit_solutions_effects(&mut *conn, vec![test_blocks[3].clone()]);
+    assert_submit_solutions_effects(&mut conn, vec![test_blocks[3].clone()]);
 }
 
 pub fn client() -> reqwest::Client {

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -69,8 +69,8 @@ async fn test_run() {
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Check block, state and validation progress
-    let conn = db.acquire().await.unwrap();
-    assert_submit_solutions_effects(&conn, vec![test_blocks[0].clone()]);
+    let mut conn = db.acquire().await.unwrap();
+    assert_submit_solutions_effects(&mut *conn, vec![test_blocks[0].clone()]);
 
     // Insert block 1 and 2 to database and send notification
     node_server
@@ -88,8 +88,11 @@ async fn test_run() {
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Check block, state and validation progress
-    let conn = db.acquire().await.unwrap();
-    assert_submit_solutions_effects(&conn, vec![test_blocks[1].clone(), test_blocks[2].clone()]);
+    let mut conn = db.acquire().await.unwrap();
+    assert_submit_solutions_effects(
+        &mut *conn,
+        vec![test_blocks[1].clone(), test_blocks[2].clone()],
+    );
 
     // Insert block 3 to database and send notification
     node_server
@@ -101,8 +104,8 @@ async fn test_run() {
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     // Check block, state and validation progress
-    let conn = db.acquire().await.unwrap();
-    assert_submit_solutions_effects(&conn, vec![test_blocks[3].clone()]);
+    let mut conn = db.acquire().await.unwrap();
+    assert_submit_solutions_effects(&mut *conn, vec![test_blocks[3].clone()]);
 }
 
 pub fn client() -> reqwest::Client {
@@ -160,12 +163,15 @@ async fn test_node() -> (NodeServer, BlockTx) {
 // Fetch blocks from node database and assert that they contain the same solutions as expected.
 // Assert state mutations in the blocks have been applied to database.
 // Assert validation progress is the latest fetched block.
-fn assert_submit_solutions_effects(conn: &Connection, expected_blocks: Vec<Block>) {
+fn assert_submit_solutions_effects(conn: &mut Connection, expected_blocks: Vec<Block>) {
+    let tx = conn.transaction().unwrap();
     let fetched_blocks = &db::list_blocks(
-        conn,
+        &tx,
         expected_blocks[0].number..expected_blocks[expected_blocks.len() - 1].number + 1,
     )
     .unwrap();
+    drop(tx);
+
     for (i, expected_block) in expected_blocks.iter().enumerate() {
         // Check if the block was added to the database
         assert_eq!(fetched_blocks[i].number, expected_block.number);

--- a/crates/rusqlite-pool/src/tokio.rs
+++ b/crates/rusqlite-pool/src/tokio.rs
@@ -98,6 +98,12 @@ impl AsyncConnectionPool {
     }
 }
 
+impl AsMut<rusqlite::Connection> for AsyncConnectionHandle {
+    fn as_mut(&mut self) -> &mut rusqlite::Connection {
+        self
+    }
+}
+
 impl AsRef<rusqlite::Connection> for AsyncConnectionHandle {
     fn as_ref(&self) -> &rusqlite::Connection {
         self


### PR DESCRIPTION
- Adds `solution_data` table
- Modifies `dec_var` and `mutation` tables to point to solution data
- Adapts solution and block queries (in sql and rust) 
  - Turns some `list_block`-like functions to accept a `Transaction` instead of a `Connection`
    - This made `node_db`s `acquire_connection` to return `AsMut` instead of `AsRef`, as transactions are created on mutable connections
- Adds more query solution tests
- Removes postcard dependency
- Fixes several db queries

Closes #56 
Closes #55 
