### PR TITLE
refactor: misc node_db related updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "essential-types",
  "serde",
  "serde_yaml",
+ "tokio",
 ]
 
 [[package]]
@@ -759,6 +760,7 @@ dependencies = [
  "essential-node",
  "essential-node-api",
  "essential-node-db",
+ "essential-node-types",
  "essential-sign",
  "essential-types",
  "futures",

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 axum = { workspace = true }
 essential-node = { workspace = true }
+essential-node-types = { workspace = true }
 essential-types = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/crates/node-api/src/endpoint.rs
+++ b/crates/node-api/src/endpoint.rs
@@ -8,7 +8,8 @@ use axum::{
     },
     Json,
 };
-use essential_node::{db, BlockRx};
+use essential_node::db;
+use essential_node_types::BlockRx;
 use essential_types::{convert::word_from_bytes, Block, ContentAddress, Value, Word};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;

--- a/crates/node-api/src/endpoint.rs
+++ b/crates/node-api/src/endpoint.rs
@@ -9,7 +9,7 @@ use axum::{
     Json,
 };
 use essential_node::db;
-use essential_node_types::BlockRx;
+use essential_node_types::block_notify::BlockRx;
 use essential_types::{convert::word_from_bytes, Block, ContentAddress, Value, Word};
 use futures::{Stream, StreamExt};
 use serde::Deserialize;

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -5,7 +5,8 @@
 //! To serve the node API, construct a [`router`], a [`TcpListener`] and call [`serve`].
 
 use axum::{routing::get, Router};
-use essential_node::{db, BlockRx};
+use essential_node::db;
+use essential_node_types::BlockRx;
 use std::{io, net::SocketAddr};
 use thiserror::Error;
 use tokio::{

--- a/crates/node-api/src/lib.rs
+++ b/crates/node-api/src/lib.rs
@@ -6,7 +6,7 @@
 
 use axum::{routing::get, Router};
 use essential_node::db;
-use essential_node_types::BlockRx;
+use essential_node_types::block_notify::BlockRx;
 use std::{io, net::SocketAddr};
 use thiserror::Error;
 use tokio::{

--- a/crates/node-api/tests/endpoints.rs
+++ b/crates/node-api/tests/endpoints.rs
@@ -1,5 +1,6 @@
-use essential_node::{self as node, BlockTx};
+use essential_node::{self as node};
 use essential_node_api as node_api;
+use essential_node_types::BlockTx;
 use essential_types::{convert::bytes_from_word, Block, Value};
 use futures::{StreamExt, TryStreamExt};
 use tokio_util::{

--- a/crates/node-api/tests/endpoints.rs
+++ b/crates/node-api/tests/endpoints.rs
@@ -1,6 +1,6 @@
 use essential_node::{self as node};
 use essential_node_api as node_api;
-use essential_node_types::BlockTx;
+use essential_node_types::block_notify::BlockTx;
 use essential_types::{convert::bytes_from_word, Block, Value};
 use futures::{StreamExt, TryStreamExt};
 use tokio_util::{

--- a/crates/node-cli/src/lib.rs
+++ b/crates/node-cli/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use essential_node::{self as node, db::pool::Config, RunConfig};
 use essential_node_api as node_api;
-use essential_node_types::{BigBang, BlockTx};
+use essential_node_types::{block_notify::BlockTx, BigBang};
 use std::{
     net::{SocketAddr, SocketAddrV4},
     path::{Path, PathBuf},

--- a/crates/node-cli/src/lib.rs
+++ b/crates/node-cli/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use essential_node::{self as node, db::pool::Config, RunConfig};
 use essential_node_api as node_api;
-use essential_node_types::BigBang;
+use essential_node_types::{BigBang, BlockTx};
 use std::{
     net::{SocketAddr, SocketAddrV4},
     path::{Path, PathBuf},
@@ -172,7 +172,7 @@ pub async fn run(args: Args) -> anyhow::Result<()> {
         }
     );
 
-    let block_tx = node::BlockTx::new();
+    let block_tx = BlockTx::new();
     let block_rx = block_tx.new_listener();
 
     let run_conf = RunConfig {

--- a/crates/node-cli/src/tests.rs
+++ b/crates/node-cli/src/tests.rs
@@ -1,6 +1,5 @@
-use std::time::Duration;
-
 use super::*;
+use std::time::Duration;
 
 #[tokio::test]
 async fn test_args() {
@@ -39,7 +38,7 @@ async fn test_args() {
 }
 
 async fn test_node() -> (impl std::future::Future<Output = ()>, u16) {
-    let block_tx = node::BlockTx::new();
+    let block_tx = BlockTx::new();
     let block_rx = block_tx.new_listener();
     let config = node::db::pool::Config {
         source: node::db::pool::Source::Memory(uuid::Uuid::new_v4().to_string()),

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [dependencies]
 essential-hash = { workspace = true }
 essential-node-db-sql = { workspace = true }
-essential-node-types = { workspace = true, optional = true }
+essential-node-types = { workspace = true, optional = true, features = ["new-block"] }
 essential-types = { workspace = true }
 futures = { workspace = true }
 num_cpus = { workspace = true, optional = true }
@@ -31,7 +31,7 @@ uuid = { workspace = true }
 
 [features]
 default = ["pool"]
-pool = [ "essential-node-types", "num_cpus", "rusqlite-pool", "rusqlite-pool/tokio", "tokio"]
+pool = [ "essential-node-types", "essential-node-types/tokio", "num_cpus", "rusqlite-pool", "rusqlite-pool/tokio", "tokio"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [dependencies]
 essential-hash = { workspace = true }
 essential-node-db-sql = { workspace = true }
-essential-node-types = { workspace = true, optional = true, features = ["new-block"] }
+essential-node-types = { workspace = true, optional = true, features = ["block-notify"] }
 essential-types = { workspace = true }
 futures = { workspace = true }
 num_cpus = { workspace = true, optional = true }

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 essential-hash = { workspace = true }
 essential-node-db-sql = { workspace = true }
+essential-node-types = { workspace = true, optional = true }
 essential-types = { workspace = true }
 futures = { workspace = true }
 num_cpus = { workspace = true, optional = true }
@@ -30,7 +31,7 @@ uuid = { workspace = true }
 
 [features]
 default = ["pool"]
-pool = ["num_cpus", "rusqlite-pool", "rusqlite-pool/tokio", "tokio"]
+pool = [ "essential-node-types", "num_cpus", "rusqlite-pool", "rusqlite-pool/tokio", "tokio"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/node-db/src/pool.rs
+++ b/crates/node-db/src/pool.rs
@@ -5,7 +5,7 @@
 
 use crate::{with_tx, AcquireConnection, AwaitNewBlock, QueryError};
 use core::ops::Range;
-use essential_node_types::BlockRx;
+use essential_node_types::block_notify::BlockRx;
 use essential_types::{solution::Solution, Block, ContentAddress, Key, Value, Word};
 use futures::Stream;
 use rusqlite_pool::tokio::{AsyncConnectionHandle, AsyncConnectionPool};

--- a/crates/node-db/src/pool.rs
+++ b/crates/node-db/src/pool.rs
@@ -5,6 +5,7 @@
 
 use crate::{with_tx, AcquireConnection, AwaitNewBlock, QueryError};
 use core::ops::Range;
+use essential_node_types::BlockRx;
 use essential_types::{solution::Solution, Block, ContentAddress, Key, Value, Word};
 use futures::Stream;
 use rusqlite_pool::tokio::{AsyncConnectionHandle, AsyncConnectionPool};
@@ -398,6 +399,12 @@ impl Source {
     pub fn default_memory() -> Self {
         // Default ID cannot be an empty string.
         Self::Memory("__default-id".to_string())
+    }
+}
+
+impl AwaitNewBlock for BlockRx {
+    async fn await_new_block(&mut self) -> Option<()> {
+        self.changed().await.ok()
     }
 }
 

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -1,33 +1,9 @@
 use essential_node_db::{self as node_db};
+use essential_node_types::BlockTx;
 use futures::StreamExt;
-use rusqlite::Connection;
-use rusqlite_pool::tokio::AsyncConnectionPool;
+use util::test_conn_pool;
 
 mod util;
-
-fn new_mem_conn(unique_id: &str) -> rusqlite::Result<Connection> {
-    let conn_str = format!("file:/{unique_id}");
-    let conn =
-        rusqlite::Connection::open_with_flags_and_vfs(conn_str, Default::default(), "memdb")?;
-    conn.pragma_update(None, "foreign_keys", true)?;
-    Ok(conn)
-}
-
-struct AcquireConn(AsyncConnectionPool);
-
-struct AwaitNewBlock(tokio::sync::watch::Receiver<()>);
-
-impl node_db::AcquireConnection for AcquireConn {
-    async fn acquire_connection(&self) -> Option<impl 'static + AsRef<Connection>> {
-        self.0.acquire().await.ok()
-    }
-}
-
-impl node_db::AwaitNewBlock for AwaitNewBlock {
-    async fn await_new_block(&mut self) -> Option<()> {
-        self.0.changed().await.ok()
-    }
-}
 
 #[tokio::test]
 async fn subscribe_blocks() {
@@ -35,12 +11,11 @@ async fn subscribe_blocks() {
     let blocks = util::test_blocks(1000);
 
     // A DB connection pool.
-    let conn_limit = 4;
-    let conn_init = || new_mem_conn("subscribe_blocks");
-    let conn_pool = AsyncConnectionPool::new(conn_limit, conn_init).unwrap();
+    let conn_pool = test_conn_pool();
 
-    // A fn for notifying of new blocks.
-    let (new_block_tx, new_block_rx) = tokio::sync::watch::channel(());
+    // Channel for notifying of new blocks
+    let new_block_tx = BlockTx::new();
+    let new_block_rx = new_block_tx.new_listener();
 
     // Write the first 10 blocks to the DB. We'll write the rest later.
     let mut conn = conn_pool.acquire().await.unwrap();
@@ -54,9 +29,7 @@ async fn subscribe_blocks() {
 
     // Subscribe to blocks.
     let start_block = 0;
-    let acq_conn = AcquireConn(conn_pool.clone());
-    let new_block = AwaitNewBlock(new_block_rx);
-    let stream = node_db::subscribe_blocks(start_block, acq_conn, new_block);
+    let stream = node_db::subscribe_blocks(start_block, conn_pool.clone(), new_block_rx);
     let mut stream = std::pin::pin!(stream);
 
     // There should be 10 blocks available already.
@@ -71,7 +44,7 @@ async fn subscribe_blocks() {
             let tx = conn.transaction().unwrap();
             node_db::insert_block(&tx, &block).unwrap();
             tx.commit().unwrap();
-            new_block_tx.clone().send(()).unwrap();
+            new_block_tx.notify();
         }
         // After writing, drop the new block tx, closing the stream.
         assert_eq!(new_block_tx.receiver_count(), 1);

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -1,5 +1,5 @@
 use essential_node_db::{self as node_db};
-use essential_node_types::BlockTx;
+use essential_node_types::block_notify::BlockTx;
 use futures::StreamExt;
 use util::test_conn_pool;
 

--- a/crates/node-types/Cargo.toml
+++ b/crates/node-types/Cargo.toml
@@ -16,5 +16,5 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true, optional = true }
 
 [features]
-default = []
-new-block = [ "tokio" ]
+default = [ "block-notify" ]
+block-notify = [ "tokio" ]

--- a/crates/node-types/Cargo.toml
+++ b/crates/node-types/Cargo.toml
@@ -13,3 +13,4 @@ essential-hash = { workspace = true }
 essential-types = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
+tokio = { workspace = true }

--- a/crates/node-types/Cargo.toml
+++ b/crates/node-types/Cargo.toml
@@ -13,4 +13,8 @@ essential-hash = { workspace = true }
 essential-types = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, optional = true }
+
+[features]
+default = []
+new-block = [ "tokio" ]

--- a/crates/node-types/src/block_notify.rs
+++ b/crates/node-types/src/block_notify.rs
@@ -1,0 +1,46 @@
+use tokio::sync::watch::{channel, error::RecvError, Receiver, Sender};
+
+/// Wrapper around `watch::Sender` to notify of new blocks.
+///
+/// This is used by `essential-builder` to notify `essential-relayer`
+/// and by `essential-relayer` to notify [`validation`] stream.
+#[derive(Clone, Default)]
+pub struct BlockTx(Sender<()>);
+
+/// Wrapper around `watch::Receiver` to listen to new blocks.
+///
+/// This is used by [`db::subscribe_blocks`] stream.
+#[derive(Clone)]
+pub struct BlockRx(Receiver<()>);
+
+impl BlockTx {
+    /// Create a new [`BlockTx`] to notify listeners of new blocks.
+    pub fn new() -> Self {
+        let (block_tx, _block_rx) = channel(());
+        Self(block_tx)
+    }
+
+    /// Notify listeners that a new block has been received.
+    ///
+    /// Note this is best effort and will still send even if there are currently no listeners.
+    pub fn notify(&self) {
+        let _ = self.0.send(());
+    }
+
+    /// Create a new [`BlockRx`] to listen for new blocks.
+    pub fn new_listener(&self) -> BlockRx {
+        BlockRx(self.0.subscribe())
+    }
+
+    /// Get the number of receivers listening for new blocks.
+    pub fn receiver_count(&self) -> usize {
+        self.0.receiver_count()
+    }
+}
+
+impl BlockRx {
+    /// Waits for a change notification.
+    pub async fn changed(&mut self) -> Result<(), RecvError> {
+        self.0.changed().await
+    }
+}

--- a/crates/node-types/src/lib.rs
+++ b/crates/node-types/src/lib.rs
@@ -67,6 +67,19 @@ pub struct BigBang {
     pub solution: Solution,
 }
 
+/// Wrapper around `watch::Sender` to notify of new blocks.
+///
+/// This is used by `essential-builder` to notify `essential-relayer`
+/// and by `essential-relayer` to notify [`validation`] stream.
+#[derive(Clone, Default)]
+pub struct BlockTx(tokio::sync::watch::Sender<()>);
+
+/// Wrapper around `watch::Receiver` to listen to new blocks.
+///
+/// This is used by [`db::subscribe_blocks`] stream.
+#[derive(Clone)]
+pub struct BlockRx(tokio::sync::watch::Receiver<()>);
+
 impl BigBang {
     /// Produce the big bang [`Block`].
     pub fn block(&self) -> Block {
@@ -82,6 +95,38 @@ impl Default for BigBang {
     fn default() -> Self {
         serde_yaml::from_str(DEFAULT_BIG_BANG)
             .expect("default `big-bang-block.yml` must be valid (checked in tests)")
+    }
+}
+
+impl BlockTx {
+    /// Create a new [`BlockTx`] to notify listeners of new blocks.
+    pub fn new() -> Self {
+        let (block_tx, _block_rx) = tokio::sync::watch::channel(());
+        Self(block_tx)
+    }
+
+    /// Notify listeners that a new block has been received.
+    ///
+    /// Note this is best effort and will still send even if there are currently no listeners.
+    pub fn notify(&self) {
+        let _ = self.0.send(());
+    }
+
+    /// Create a new [`BlockRx`] to listen for new blocks.
+    pub fn new_listener(&self) -> BlockRx {
+        BlockRx(self.0.subscribe())
+    }
+
+    /// Get the number of receivers listening for new blocks.
+    pub fn receiver_count(&self) -> usize {
+        self.0.receiver_count()
+    }
+}
+
+impl BlockRx {
+    /// Waits for a change notification.
+    pub async fn changed(&mut self) -> Result<(), tokio::sync::watch::error::RecvError> {
+        self.0.changed().await
     }
 }
 

--- a/crates/node-types/src/lib.rs
+++ b/crates/node-types/src/lib.rs
@@ -67,6 +67,7 @@ pub struct BigBang {
     pub solution: Solution,
 }
 
+#[cfg(feature = "new-block")]
 /// Wrapper around `watch::Sender` to notify of new blocks.
 ///
 /// This is used by `essential-builder` to notify `essential-relayer`
@@ -74,6 +75,7 @@ pub struct BigBang {
 #[derive(Clone, Default)]
 pub struct BlockTx(tokio::sync::watch::Sender<()>);
 
+#[cfg(feature = "new-block")]
 /// Wrapper around `watch::Receiver` to listen to new blocks.
 ///
 /// This is used by [`db::subscribe_blocks`] stream.
@@ -98,6 +100,7 @@ impl Default for BigBang {
     }
 }
 
+#[cfg(feature = "new-block")]
 impl BlockTx {
     /// Create a new [`BlockTx`] to notify listeners of new blocks.
     pub fn new() -> Self {
@@ -123,6 +126,7 @@ impl BlockTx {
     }
 }
 
+#[cfg(feature = "new-block")]
 impl BlockRx {
     /// Waits for a change notification.
     pub async fn changed(&mut self) -> Result<(), tokio::sync::watch::error::RecvError> {

--- a/crates/node-types/src/lib.rs
+++ b/crates/node-types/src/lib.rs
@@ -12,6 +12,10 @@ use essential_types::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Wrappers around tokio's `watch` channel for notifying of new blocks.
+#[cfg(feature = "block-notify")]
+pub mod block_notify;
+
 /// The default big-bang configuration.
 pub const DEFAULT_BIG_BANG: &str = include_str!("../big-bang.yml");
 
@@ -67,21 +71,6 @@ pub struct BigBang {
     pub solution: Solution,
 }
 
-#[cfg(feature = "new-block")]
-/// Wrapper around `watch::Sender` to notify of new blocks.
-///
-/// This is used by `essential-builder` to notify `essential-relayer`
-/// and by `essential-relayer` to notify [`validation`] stream.
-#[derive(Clone, Default)]
-pub struct BlockTx(tokio::sync::watch::Sender<()>);
-
-#[cfg(feature = "new-block")]
-/// Wrapper around `watch::Receiver` to listen to new blocks.
-///
-/// This is used by [`db::subscribe_blocks`] stream.
-#[derive(Clone)]
-pub struct BlockRx(tokio::sync::watch::Receiver<()>);
-
 impl BigBang {
     /// Produce the big bang [`Block`].
     pub fn block(&self) -> Block {
@@ -97,40 +86,6 @@ impl Default for BigBang {
     fn default() -> Self {
         serde_yaml::from_str(DEFAULT_BIG_BANG)
             .expect("default `big-bang-block.yml` must be valid (checked in tests)")
-    }
-}
-
-#[cfg(feature = "new-block")]
-impl BlockTx {
-    /// Create a new [`BlockTx`] to notify listeners of new blocks.
-    pub fn new() -> Self {
-        let (block_tx, _block_rx) = tokio::sync::watch::channel(());
-        Self(block_tx)
-    }
-
-    /// Notify listeners that a new block has been received.
-    ///
-    /// Note this is best effort and will still send even if there are currently no listeners.
-    pub fn notify(&self) {
-        let _ = self.0.send(());
-    }
-
-    /// Create a new [`BlockRx`] to listen for new blocks.
-    pub fn new_listener(&self) -> BlockRx {
-        BlockRx(self.0.subscribe())
-    }
-
-    /// Get the number of receivers listening for new blocks.
-    pub fn receiver_count(&self) -> usize {
-        self.0.receiver_count()
-    }
-}
-
-#[cfg(feature = "new-block")]
-impl BlockRx {
-    /// Waits for a change notification.
-    pub async fn changed(&mut self) -> Result<(), tokio::sync::watch::error::RecvError> {
-        self.0.changed().await
     }
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -10,8 +10,7 @@
 
 use error::{BigBangError, CriticalError};
 pub use essential_node_db as db;
-use essential_node_types::BigBang;
-use essential_node_types::BlockTx;
+use essential_node_types::{block_notify::BlockTx, BigBang};
 use essential_relayer::Relayer;
 use essential_types::ContentAddress;
 pub use handles::node::Handle;

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -11,6 +11,7 @@
 use error::{BigBangError, CriticalError};
 pub use essential_node_db as db;
 use essential_node_types::BigBang;
+use essential_node_types::BlockTx;
 use essential_relayer::Relayer;
 use essential_types::ContentAddress;
 pub use handles::node::Handle;
@@ -25,19 +26,6 @@ mod handles;
 pub mod test_utils;
 pub mod validate;
 mod validation;
-
-/// Wrapper around `watch::Sender` to notify of new blocks.
-///
-/// This is used by `essential-builder` to notify `essential-relayer`
-/// and by `essential-relayer` to notify [`validation`] stream.
-#[derive(Clone, Default)]
-pub struct BlockTx(tokio::sync::watch::Sender<()>);
-
-/// Wrapper around `watch::Receiver` to listen to new blocks.
-///
-/// This is used by [`db::subscribe_blocks`] stream.
-#[derive(Clone)]
-pub struct BlockRx(tokio::sync::watch::Receiver<()>);
 
 /// Options for running the node.
 #[derive(Clone, Debug)]
@@ -134,7 +122,7 @@ pub fn run(
     // Run relayer.
     let relayer_handle = if let Some(relayer_source_endpoint) = relayer_source_endpoint {
         let relayer = Relayer::new(relayer_source_endpoint.as_str())?;
-        Some(relayer.run(conn_pool.clone(), block_notify.0.clone())?)
+        Some(relayer.run(conn_pool.clone(), block_notify.clone())?)
     } else {
         None
     };
@@ -144,38 +132,11 @@ pub fn run(
         Some(validation_stream(
             conn_pool.clone(),
             contract_registry,
-            block_notify.new_listener().0,
+            block_notify.new_listener(),
         )?)
     } else {
         None
     };
 
     Ok(Handle::new(relayer_handle, validation_handle))
-}
-
-impl BlockTx {
-    /// Create a new [`BlockTx`] to notify listeners of new blocks.
-    pub fn new() -> Self {
-        let (block_tx, _block_rx) = tokio::sync::watch::channel(());
-        Self(block_tx)
-    }
-
-    /// Notify listeners that a new block has been received.
-    ///
-    /// Note this is best effort and will still send even if there are currently no listeners.
-    pub fn notify(&self) {
-        let _ = self.0.send(());
-    }
-
-    /// Create a new [`BlockRx`] to listen for new blocks.
-    pub fn new_listener(&self) -> BlockRx {
-        BlockRx(self.0.subscribe())
-    }
-}
-
-impl BlockRx {
-    /// Waits for a change notification.
-    pub async fn changed(&mut self) -> Result<(), tokio::sync::watch::error::RecvError> {
-        self.0.changed().await
-    }
 }

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use essential_hash::content_addr;
 use essential_node_db::QueryError;
-use essential_node_types::BlockRx;
+use essential_node_types::block_notify::BlockRx;
 use essential_types::{Block, ContentAddress};
 use tokio::sync::watch;
 

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use essential_hash::content_addr;
 use essential_node_db::QueryError;
+use essential_node_types::BlockRx;
 use essential_types::{Block, ContentAddress};
 use tokio::sync::watch;
 
@@ -28,7 +29,7 @@ mod tests;
 pub fn validation_stream(
     conn_pool: ConnectionPool,
     contract_registry: ContentAddress,
-    mut block_rx: watch::Receiver<()>,
+    mut block_rx: BlockRx,
 ) -> Result<Handle<CriticalError>, CriticalError> {
     let (shutdown, stream_close) = watch::channel(());
 

--- a/crates/node/src/validation/tests.rs
+++ b/crates/node/src/validation/tests.rs
@@ -6,7 +6,7 @@ use crate::{
         test_conn_pool_with_big_bang, test_contract_registry, test_invalid_block_with_contract,
     },
 };
-use essential_node_types::{BigBang, BlockTx};
+use essential_node_types::{block_notify::BlockTx, BigBang};
 use essential_types::{Block, Word};
 use rusqlite::Connection;
 use std::time::Duration;

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -12,9 +12,9 @@ use essential_node::{
         assert_multiple_block_mutations, assert_validation_progress_is_some,
         test_blocks_with_contracts, test_db_conf,
     },
-    BlockTx, RunConfig,
+    RunConfig,
 };
-use essential_node_types::BigBang;
+use essential_node_types::{BigBang, BlockTx};
 use essential_types::Block;
 use rusqlite::Connection;
 

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -14,7 +14,7 @@ use essential_node::{
     },
     RunConfig,
 };
-use essential_node_types::{BigBang, BlockTx};
+use essential_node_types::{block_notify::BlockTx, BigBang};
 use essential_types::Block;
 use rusqlite::Connection;
 

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 essential-hash.workspace = true
 essential-node-db.workspace = true
+essential-node-types.workspace = true
 essential-types.workspace = true
 futures.workspace = true
 reqwest = { workspace = true, features = ["json", "stream", "native-tls-alpn"] }

--- a/crates/relayer/src/lib.rs
+++ b/crates/relayer/src/lib.rs
@@ -10,7 +10,7 @@ use error::InternalError;
 use error::InternalResult;
 pub use error::Result;
 use essential_node_db::{self as db, ConnectionPool};
-use essential_node_types::BlockTx;
+use essential_node_types::block_notify::BlockTx;
 use futures::StreamExt;
 pub use handle::Handle;
 use reqwest::{ClientBuilder, Url};

--- a/crates/relayer/src/lib.rs
+++ b/crates/relayer/src/lib.rs
@@ -10,6 +10,7 @@ use error::InternalError;
 use error::InternalResult;
 pub use error::Result;
 use essential_node_db::{self as db, ConnectionPool};
+use essential_node_types::BlockTx;
 use futures::StreamExt;
 pub use handle::Handle;
 use reqwest::{ClientBuilder, Url};
@@ -49,7 +50,7 @@ impl Relayer {
     /// A handle is returned that can be used to close or join the streams.
     ///
     /// The two watch channels are used to notify the caller when new data has been synced.
-    pub fn run(self, pool: ConnectionPool, new_block: watch::Sender<()>) -> Result<Handle> {
+    pub fn run(self, pool: ConnectionPool, new_block: BlockTx) -> Result<Handle> {
         // The blocks callback. This is a closure that will be called
         // every time the blocks stream is restarted.
         let blocks = move |shutdown: watch::Receiver<()>| {
@@ -71,7 +72,7 @@ impl Relayer {
         &self,
         conn: ConnectionPool,
         mut shutdown: watch::Receiver<()>,
-        notify: watch::Sender<()>,
+        notify: BlockTx,
     ) -> InternalResult<()> {
         #[cfg(feature = "tracing")]
         tracing::info!("Stream starting");

--- a/crates/relayer/src/sync.rs
+++ b/crates/relayer/src/sync.rs
@@ -1,10 +1,10 @@
 use essential_node_db::{self as db, with_tx, ConnectionPool};
+use essential_node_types::BlockTx;
 use essential_types::Block;
 use essential_types::ContentAddress;
 use essential_types::Word;
 use futures::stream::TryStreamExt;
 use futures::Stream;
-use tokio::sync::watch;
 
 pub(crate) use streams::stream_blocks;
 
@@ -52,7 +52,7 @@ pub async fn get_block_progress(
 pub async fn sync_blocks<S>(
     pool: ConnectionPool,
     progress: &Option<BlockProgress>,
-    notify: watch::Sender<()>,
+    notify: BlockTx,
     stream: S,
 ) -> InternalResult<()>
 where
@@ -110,7 +110,7 @@ where
                     .map_err(CriticalError::from)?;
 
                 // Best effort to notify of new block
-                let _ = notify.send(());
+                notify.notify();
                 Ok(())
             }
         })

--- a/crates/relayer/src/sync.rs
+++ b/crates/relayer/src/sync.rs
@@ -1,5 +1,5 @@
 use essential_node_db::{self as db, with_tx, ConnectionPool};
-use essential_node_types::BlockTx;
+use essential_node_types::block_notify::BlockTx;
 use essential_types::Block;
 use essential_types::ContentAddress;
 use essential_types::Word;

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -3,7 +3,7 @@ use essential_node::db::{
     pool::{Config, Source},
     ConnectionPool,
 };
-use essential_node_types::BlockTx;
+use essential_node_types::block_notify::BlockTx;
 use essential_relayer::{DataSyncError, Relayer};
 use essential_types::{
     contract::Contract,

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -1,11 +1,9 @@
-use essential_node::{
-    db::{
-        self,
-        pool::{Config, Source},
-        ConnectionPool,
-    },
-    BlockTx,
+use essential_node::db::{
+    self,
+    pool::{Config, Source},
+    ConnectionPool,
 };
+use essential_node_types::BlockTx;
 use essential_relayer::{DataSyncError, Relayer};
 use essential_types::{
     contract::Contract,
@@ -29,7 +27,7 @@ struct NodeServer {
 async fn test_sync() {
     let relayer_conn = new_conn_pool();
 
-    let (node_server, block_tx) = test_node().await;
+    let (node_server, source_block_tx) = test_node().await;
     let source_db = node_server.conn_pool.clone();
 
     let mut test_conn = relayer_conn.acquire().await.unwrap();
@@ -40,13 +38,14 @@ async fn test_sync() {
     let (solutions, blocks) = test_structs();
 
     source_db.insert_block(blocks[0].clone()).await.unwrap();
-    block_tx.notify();
+    source_block_tx.notify();
 
     let relayer = Relayer::new(node_server.address.as_str()).unwrap();
-    let (block_notify, mut new_block) = tokio::sync::watch::channel(());
-    let relayer_handle = relayer.run(relayer_conn.clone(), block_notify).unwrap();
+    let block_tx = BlockTx::new();
+    let mut block_rx = block_tx.new_listener();
+    let relayer_handle = relayer.run(relayer_conn.clone(), block_tx.clone()).unwrap();
 
-    new_block.changed().await.unwrap();
+    block_rx.changed().await.unwrap();
     let result = db::list_blocks(&test_conn, 0..100).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].number, 0);
@@ -54,9 +53,9 @@ async fn test_sync() {
     assert_eq!(result[0].solutions[0], solutions[0]);
 
     source_db.insert_block(blocks[1].clone()).await.unwrap();
-    block_tx.notify();
+    source_block_tx.notify();
 
-    new_block.changed().await.unwrap();
+    block_rx.changed().await.unwrap();
     let result = db::list_blocks(&test_conn, 0..100).unwrap();
     assert_eq!(result.len(), 2);
     assert_eq!(result[1].number, 1);
@@ -67,11 +66,11 @@ async fn test_sync() {
 
     for block in &blocks[2..] {
         source_db.insert_block(block.clone()).await.unwrap();
-        block_tx.notify();
+        source_block_tx.notify();
     }
     let relayer = Relayer::new(node_server.address.as_str()).unwrap();
-    let (block_notify, _new_block) = tokio::sync::watch::channel(());
-    let relayer_handle = relayer.run(relayer_conn.clone(), block_notify).unwrap();
+    let block_tx = BlockTx::new();
+    let relayer_handle = relayer.run(relayer_conn.clone(), block_tx).unwrap();
 
     let start = tokio::time::Instant::now();
     let mut num_solutions: usize = 0;
@@ -106,9 +105,9 @@ async fn test_sync() {
     let (node_server, ..) = test_node().await;
 
     let relayer = Relayer::new(node_server.address.as_str()).unwrap();
-    let (block_notify, _new_block) = tokio::sync::watch::channel(());
+    let block_tx = BlockTx::new();
 
-    let relayer_handle = relayer.run(relayer_conn, block_notify).unwrap();
+    let relayer_handle = relayer.run(relayer_conn, block_tx).unwrap();
     tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     let r = relayer_handle.close().await;
     assert!(


### PR DESCRIPTION
Followup to #115

- Moves BlockRx and BlockTx to essential-node-types
- Adds `fn receiver_count` to BlockTx
- Implements AwaitNewBlock for BlockRx in node-db pool
- Updates node db tests to use existing utils
- Changes node's validation stream to accept BlockRx instead of watch::Receiver
- Changes relayer's run function and relevant functions called from within to accept BlockTx instead of watch::Sender