### PR TITLE
Node-db function reuse

### DIFF
--- a/crates/node-db/src/lib.rs
+++ b/crates/node-db/src/lib.rs
@@ -694,6 +694,21 @@ where
     Ok(out)
 }
 
+/// Short-hand for constructing a transaction, providing it as an argument to
+/// the given function, then dropping the transaction before returning.
+pub fn with_tx_dropped<T, E>(
+    conn: &mut rusqlite::Connection,
+    f: impl FnOnce(&mut Transaction) -> Result<T, E>,
+) -> Result<T, E>
+where
+    E: From<rusqlite::Error>,
+{
+    let mut tx = conn.transaction()?;
+    let out = f(&mut tx)?;
+    drop(tx);
+    Ok(out)
+}
+
 /// Convert a slice of `Word`s into a blob.
 pub fn blob_from_words(words: &[Word]) -> Vec<u8> {
     words.iter().copied().flat_map(bytes_from_word).collect()

--- a/crates/node-db/tests/create.rs
+++ b/crates/node-db/tests/create.rs
@@ -6,9 +6,7 @@ mod util;
 #[test]
 fn create_tables() {
     let mut conn = test_conn();
-    let tx = conn.transaction().unwrap();
-    node_db::create_tables(&tx).unwrap();
-    tx.commit().unwrap();
+    let _ = node_db::with_tx(&mut conn, |tx| node_db::create_tables(tx));
 
     // Verify that each table exists by querying the SQLite master table
     for table in node_db::sql::table::ALL {

--- a/crates/node-db/tests/create.rs
+++ b/crates/node-db/tests/create.rs
@@ -6,7 +6,7 @@ mod util;
 #[test]
 fn create_tables() {
     let mut conn = test_conn();
-    let _ = node_db::with_tx(&mut conn, |tx| node_db::create_tables(tx));
+    node_db::with_tx(&mut conn, |tx| node_db::create_tables(tx)).unwrap();
 
     // Verify that each table exists by querying the SQLite master table
     for table in node_db::sql::table::ALL {

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -192,11 +192,7 @@ fn test_finalize_block() {
         Duration::from_secs((NUM_FINALIZED_BLOCKS + 1000) as u64),
     );
 
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        node_db::insert_block(tx, &fork).unwrap();
-        Ok(())
-    })
-    .unwrap();
+    node_db::with_tx(&mut conn, |tx| node_db::insert_block(tx, &fork)).unwrap();
 
     let e = node_db::finalize_block(&conn, &content_addr(&fork)).unwrap_err();
     assert!(matches!(

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -134,7 +134,6 @@ fn test_finalize_block() {
     // Create an in-memory SQLite database
     let mut conn = test_conn();
 
-    // let mut fetched_blocks = vec![];
     node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
         // Create the necessary tables and insert blocks
         node_db::create_tables(tx).unwrap();

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -17,15 +17,13 @@ fn test_insert_block() {
     // Create an in-memory SQLite database
     let mut conn = test_conn();
 
-    let mut fetched_blocks = vec![];
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+    let fetched_blocks = node_db::with_tx(&mut conn, |tx| {
         // Create the necessary tables and insert blocks
         node_db::create_tables(tx).unwrap();
         for block in &blocks {
             node_db::insert_block(tx, block).unwrap();
         }
-        fetched_blocks = node_db::list_blocks(tx, 0..100).unwrap();
-        Ok(())
+        node_db::list_blocks(tx, 0..100)
     })
     .unwrap();
 

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -217,15 +217,13 @@ fn test_failed_block() {
     // Create an in-memory SQLite database
     let mut conn = test_conn();
 
-    let mut r = vec![];
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        // Create the necessary tables and insert the block.
+    // Create the necessary tables and insert the block.
+    let r = node_db::with_tx(&mut conn, |tx| {
         node_db::create_tables(tx).unwrap();
         for block in &blocks {
             node_db::insert_block(tx, block).unwrap();
         }
-        r = node_db::list_blocks(tx, 0..(NUM_BLOCKS + 10)).unwrap();
-        Ok(())
+        node_db::list_blocks(tx, 0..(NUM_BLOCKS + 10))
     })
     .unwrap();
 

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -132,7 +132,7 @@ fn test_finalize_block() {
     // Create an in-memory SQLite database
     let mut conn = test_conn();
 
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+    let r = node_db::with_tx(&mut conn, |tx| {
         // Create the necessary tables and insert blocks
         node_db::create_tables(tx).unwrap();
         for block in &blocks {
@@ -151,11 +151,11 @@ fn test_finalize_block() {
         }
 
         // Should not change list blocks
-        let r = node_db::list_blocks(tx, 0..(NUM_BLOCKS + 10)).unwrap();
-        assert_eq!(r.len(), NUM_BLOCKS as usize);
-        Ok(())
+        node_db::list_blocks(tx, 0..(NUM_BLOCKS + 10))
     })
     .unwrap();
+
+    assert_eq!(r.len(), NUM_BLOCKS as usize);
 
     // Check the latest finalized block hash.
     let latest_finalized_block_address =

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -235,14 +235,14 @@ fn test_failed_block() {
     node_db::insert_failed_block(&conn, &block_address, &solution_hash).unwrap();
 
     // Check failed blocks.
-    let mut failed_blocks = node_db::list_failed_blocks(&conn, 0..(NUM_BLOCKS + 10)).unwrap();
+    let failed_blocks = node_db::list_failed_blocks(&conn, 0..(NUM_BLOCKS + 10)).unwrap();
     assert_eq!(failed_blocks.len(), 1);
     assert_eq!(failed_blocks[0].0, blocks[0].number);
     assert_eq!(failed_blocks[0].1, solution_hash);
 
     // Same failed block should not be inserted again.
     node_db::insert_failed_block(&conn, &block_address, &solution_hash).unwrap();
-    failed_blocks = node_db::list_failed_blocks(&conn, 0..(NUM_BLOCKS + 10)).unwrap();
+    let failed_blocks = node_db::list_failed_blocks(&conn, 0..(NUM_BLOCKS + 10)).unwrap();
     assert_eq!(failed_blocks.len(), 1);
     assert_eq!(failed_blocks[0].0, blocks[0].number);
     assert_eq!(failed_blocks[0].1, solution_hash);
@@ -252,7 +252,7 @@ fn test_failed_block() {
     let solution_hash = content_addr(blocks[1].solutions.first().unwrap());
     node_db::insert_failed_block(&conn, &block_address, &solution_hash).unwrap();
 
-    failed_blocks = node_db::with_tx_dropped(&mut conn, |tx| {
+    let failed_blocks = node_db::with_tx_dropped(&mut conn, |tx| {
         let r = node_db::list_blocks(tx, 0..(NUM_BLOCKS + 10)).unwrap();
         assert_eq!(r.len(), 2);
         assert_eq!(&blocks[1], &r[1]);

--- a/crates/node-db/tests/insert.rs
+++ b/crates/node-db/tests/insert.rs
@@ -17,13 +17,13 @@ fn test_insert_block() {
     // Create an in-memory SQLite database
     let mut conn = test_conn();
 
-    let fetched_blocks = node_db::with_tx(&mut conn, |tx| {
-        // Create the necessary tables and insert blocks
+    // Create the necessary tables and insert blocks
+    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
         node_db::create_tables(tx).unwrap();
         for block in &blocks {
-            node_db::insert_block(tx, block).unwrap();
+            node_db::insert_block(tx, block)?;
         }
-        node_db::list_blocks(tx, 0..100)
+        Ok(())
     })
     .unwrap();
 

--- a/crates/node-db/tests/query.rs
+++ b/crates/node-db/tests/query.rs
@@ -1,5 +1,5 @@
 use essential_hash::content_addr;
-use essential_node_db::{self as node_db, QueryError};
+use essential_node_db::{self as node_db};
 use essential_types::{Block, ContentAddress, Word};
 use std::time::Duration;
 use util::{test_block, test_blocks_with_vars, test_conn};
@@ -115,12 +115,11 @@ fn test_get_validation_progress() {
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
 
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+    node_db::with_tx(&mut conn, |tx| {
         // Create the necessary tables and insert the contract progress.
         node_db::create_tables(tx).unwrap();
         node_db::insert_block(tx, &block).unwrap();
-        node_db::update_validation_progress(tx, &block_address).unwrap();
-        Ok(())
+        node_db::update_validation_progress(tx, &block_address)
     })
     .unwrap();
 
@@ -138,15 +137,13 @@ fn test_list_blocks() {
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
 
-    let mut fetched_blocks = vec![];
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+    let fetched_blocks = node_db::with_tx(&mut conn, |tx| {
         // Create the necessary tables and insert blocks
         node_db::create_tables(tx).unwrap();
         for block in &blocks {
             node_db::insert_block(tx, block).unwrap();
         }
-        fetched_blocks = node_db::list_blocks(tx, 0..100).unwrap();
-        Ok(())
+        node_db::list_blocks(tx, 0..100)
     })
     .unwrap();
     assert_eq!(blocks, fetched_blocks);
@@ -160,23 +157,18 @@ fn test_list_blocks_by_time() {
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
 
-    let mut fetched_blocks = vec![];
-    let mut start_time = Duration::default();
-    let mut end_time = Duration::default();
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        // Create the necessary tables and insert blocks
-        node_db::create_tables(tx).unwrap();
-        for block in &blocks {
-            node_db::insert_block(tx, block).unwrap();
-        }
-        // List the blocks by time.
-        start_time = Duration::from_secs(3);
-        end_time = Duration::from_secs(6);
+    // Create the necessary tables and insert blocks.
+    let tx = conn.transaction().unwrap();
+    node_db::create_tables(&tx).unwrap();
+    for block in &blocks {
+        node_db::insert_block(&tx, block).unwrap();
+    }
 
-        fetched_blocks = node_db::list_blocks_by_time(tx, start_time..end_time, 10, 0).unwrap();
-        Ok(())
-    })
-    .unwrap();
+    // List the blocks by time.
+    let start_time = Duration::from_secs(3);
+    let end_time = Duration::from_secs(6);
+    let fetched_blocks = node_db::list_blocks_by_time(&tx, start_time..end_time, 10, 0).unwrap();
+    tx.commit().unwrap();
 
     // Filter the original blocks to match the time range.
     let expected_blocks: Vec<_> = blocks
@@ -195,15 +187,13 @@ fn get_block_header() {
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
 
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        // Create the necessary tables and insert blocks
-        node_db::create_tables(tx).unwrap();
-        for block in &blocks {
-            node_db::insert_block(tx, block).unwrap();
-        }
-        Ok(())
-    })
-    .unwrap();
+    // Create the necessary tables and insert blocks.
+    let tx = conn.transaction().unwrap();
+    node_db::create_tables(&tx).unwrap();
+    for block in &blocks {
+        node_db::insert_block(&tx, block).unwrap();
+    }
+    tx.commit().unwrap();
 
     // Fetch the headers and check they match.
     let fetched_headers: Vec<_> = blocks

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -20,7 +20,7 @@ async fn subscribe_blocks() {
     // Write the first 10 blocks to the DB. We'll write the rest later.
     let mut conn = conn_pool.acquire().await.unwrap();
     node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        node_db::create_tables(&tx).unwrap();
+        node_db::create_tables(tx).unwrap();
         for block in &blocks[..10] {
             node_db::insert_block(tx, block).unwrap();
         }
@@ -45,7 +45,7 @@ async fn subscribe_blocks() {
         for block in blocks_remaining {
             let mut conn = conn_pool.acquire().await.unwrap();
             node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-                node_db::insert_block(&tx, &block).unwrap();
+                node_db::insert_block(tx, &block).unwrap();
                 Ok(())
             })
             .unwrap();

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -25,7 +25,8 @@ async fn subscribe_blocks() {
             node_db::insert_block(tx, block).unwrap();
         }
         Ok(())
-    }).unwrap();
+    })
+    .unwrap();
 
     std::mem::drop(conn);
 
@@ -46,7 +47,8 @@ async fn subscribe_blocks() {
             node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
                 node_db::insert_block(&tx, &block).unwrap();
                 Ok(())
-            }).unwrap();
+            })
+            .unwrap();
 
             new_block_tx.notify();
         }

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -1,4 +1,4 @@
-use essential_node_db::{self as node_db};
+use essential_node_db::{self as node_db, QueryError};
 use essential_node_types::block_notify::BlockTx;
 use futures::StreamExt;
 use util::test_conn_pool;
@@ -19,12 +19,14 @@ async fn subscribe_blocks() {
 
     // Write the first 10 blocks to the DB. We'll write the rest later.
     let mut conn = conn_pool.acquire().await.unwrap();
-    let tx = conn.transaction().unwrap();
-    node_db::create_tables(&tx).unwrap();
-    for block in &blocks[..10] {
-        node_db::insert_block(&tx, block).unwrap();
-    }
-    tx.commit().unwrap();
+    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+        node_db::create_tables(&tx).unwrap();
+        for block in &blocks[..10] {
+            node_db::insert_block(tx, block).unwrap();
+        }
+        Ok(())
+    }).unwrap();
+
     std::mem::drop(conn);
 
     // Subscribe to blocks.
@@ -41,9 +43,11 @@ async fn subscribe_blocks() {
     let jh = tokio::spawn(async move {
         for block in blocks_remaining {
             let mut conn = conn_pool.acquire().await.unwrap();
-            let tx = conn.transaction().unwrap();
-            node_db::insert_block(&tx, &block).unwrap();
-            tx.commit().unwrap();
+            node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+                node_db::insert_block(&tx, &block).unwrap();
+                Ok(())
+            }).unwrap();
+
             new_block_tx.notify();
         }
         // After writing, drop the new block tx, closing the stream.

--- a/crates/node-db/tests/subscribe.rs
+++ b/crates/node-db/tests/subscribe.rs
@@ -1,4 +1,4 @@
-use essential_node_db::{self as node_db, QueryError};
+use essential_node_db::{self as node_db};
 use essential_node_types::block_notify::BlockTx;
 use futures::StreamExt;
 use util::test_conn_pool;
@@ -19,14 +19,12 @@ async fn subscribe_blocks() {
 
     // Write the first 10 blocks to the DB. We'll write the rest later.
     let mut conn = conn_pool.acquire().await.unwrap();
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        node_db::create_tables(tx).unwrap();
-        for block in &blocks[..10] {
-            node_db::insert_block(tx, block).unwrap();
-        }
-        Ok(())
-    })
-    .unwrap();
+    let tx = conn.transaction().unwrap();
+    node_db::create_tables(&tx).unwrap();
+    for block in &blocks[..10] {
+        node_db::insert_block(&tx, block).unwrap();
+    }
+    tx.commit().unwrap();
 
     std::mem::drop(conn);
 
@@ -44,11 +42,7 @@ async fn subscribe_blocks() {
     let jh = tokio::spawn(async move {
         for block in blocks_remaining {
             let mut conn = conn_pool.acquire().await.unwrap();
-            node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-                node_db::insert_block(tx, &block).unwrap();
-                Ok(())
-            })
-            .unwrap();
+            node_db::with_tx(&mut conn, |tx| node_db::insert_block(tx, &block)).unwrap();
 
             new_block_tx.notify();
         }

--- a/crates/node-db/tests/update.rs
+++ b/crates/node-db/tests/update.rs
@@ -17,12 +17,12 @@ fn test_state_value() {
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
 
-    let mut contract_ca = ContentAddress { 0: [0u8; 32] };
+    let mut contract_ca = ContentAddress([0u8; 32]);
     node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        node_db::create_tables(&tx)?;
+        node_db::create_tables(tx)?;
         // Write some state.
         contract_ca = essential_hash::content_addr(&contract);
-        node_db::update_state(&tx, &contract_ca, &key, &value)?;
+        node_db::update_state(tx, &contract_ca, &key, &value)?;
         Ok(())
     })
     .unwrap();
@@ -53,13 +53,13 @@ fn test_state_values_with_deletion() {
 
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
-    let mut contract_ca = ContentAddress { 0: [0u8; 32] };
+    let mut contract_ca = ContentAddress([0u8; 32]);
     node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
         // Create tables, contract, insert values.
-        node_db::create_tables(&tx)?;
+        node_db::create_tables(tx)?;
         contract_ca = essential_hash::content_addr(&contract);
         for (k, v) in keys.iter().zip(&values) {
-            node_db::update_state(&tx, &contract_ca, k, v)?;
+            node_db::update_state(tx, &contract_ca, k, v)?;
         }
         Ok(())
     })

--- a/crates/node-db/tests/update.rs
+++ b/crates/node-db/tests/update.rs
@@ -1,6 +1,6 @@
 //! Tests around state.
 
-use essential_node_db::{self as node_db};
+use essential_node_db as node_db;
 use essential_types::{Key, Value};
 use util::test_conn;
 

--- a/crates/node-db/tests/update.rs
+++ b/crates/node-db/tests/update.rs
@@ -1,6 +1,6 @@
 //! Tests around state.
 
-use essential_node_db::{self as node_db, QueryError};
+use essential_node_db::{self as node_db};
 use essential_types::{ContentAddress, Key, Value};
 use util::test_conn;
 
@@ -18,12 +18,11 @@ fn test_state_value() {
     let mut conn = test_conn();
 
     let mut contract_ca = ContentAddress([0u8; 32]);
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
+    node_db::with_tx(&mut conn, |tx| {
         node_db::create_tables(tx)?;
         // Write some state.
         contract_ca = essential_hash::content_addr(&contract);
-        node_db::update_state(tx, &contract_ca, &key, &value)?;
-        Ok(())
+        node_db::update_state(tx, &contract_ca, &key, &value)
     })
     .unwrap();
 
@@ -53,17 +52,15 @@ fn test_state_values_with_deletion() {
 
     // Create an in-memory SQLite database.
     let mut conn = test_conn();
-    let mut contract_ca = ContentAddress([0u8; 32]);
-    node_db::with_tx::<_, QueryError>(&mut conn, |tx| {
-        // Create tables, contract, insert values.
-        node_db::create_tables(tx)?;
-        contract_ca = essential_hash::content_addr(&contract);
-        for (k, v) in keys.iter().zip(&values) {
-            node_db::update_state(tx, &contract_ca, k, v)?;
-        }
-        Ok(())
-    })
-    .unwrap();
+    let tx = conn.transaction().unwrap();
+
+    // Create tables, contract, insert values.
+    node_db::create_tables(&tx).unwrap();
+    let contract_ca = essential_hash::content_addr(&contract);
+    for (k, v) in keys.iter().zip(&values) {
+        node_db::update_state(&tx, &contract_ca, k, v).unwrap();
+    }
+    tx.commit().unwrap();
 
     // Fetch the state values.
     let mut fetched = vec![];

--- a/crates/node-db/tests/update.rs
+++ b/crates/node-db/tests/update.rs
@@ -24,7 +24,8 @@ fn test_state_value() {
         contract_ca = essential_hash::content_addr(&contract);
         node_db::update_state(&tx, &contract_ca, &key, &value)?;
         Ok(())
-    }).unwrap();
+    })
+    .unwrap();
 
     // Fetch the state value.
     let fetched_value = node_db::query_state(&conn, &contract_ca, &key)

--- a/crates/node/src/error.rs
+++ b/crates/node/src/error.rs
@@ -1,5 +1,5 @@
 use crate::db::{
-    pool::{AcquireThenQueryError, AcquireThenRusqliteError},
+    pool::{AcquireThenQueryError, AcquireThenRusqliteError, AcquireThenError},
     QueryError,
 };
 use essential_types::{predicate, ContentAddress, PredicateAddress};
@@ -165,6 +165,16 @@ impl From<ValidationError> for InternalError {
                 InternalError::Recoverable(RecoverableError::Rusqlite(err))
             }
             ValidationError::Join(err) => InternalError::Recoverable(RecoverableError::Join(err)),
+        }
+    }
+}
+
+impl From<AcquireThenError<StateReadError>> for StateReadError {
+    fn from(error: AcquireThenError<StateReadError>) -> Self {
+        match error {
+            AcquireThenError::Acquire(err) => StateReadError::DbPoolClosed(err),
+            AcquireThenError::Inner(err) => err,
+            AcquireThenError::Join(err) => StateReadError::Join(err),
         }
     }
 }

--- a/crates/node/src/error.rs
+++ b/crates/node/src/error.rs
@@ -191,22 +191,6 @@ impl From<AcquireThenError<ValidationError>> for InternalError {
     }
 }
 
-impl From<AcquireThenError<StateReadError>> for ValidationError {
-    fn from(error: AcquireThenError<StateReadError>) -> Self {
-        match error {
-            AcquireThenError::Acquire(err) => ValidationError::DbPoolClosed(err),
-            AcquireThenError::Inner(err) => match err {
-                StateReadError::Query(query_err) => ValidationError::Query(query_err),
-                StateReadError::DbPoolClosed(db_err) => ValidationError::DbPoolClosed(db_err),
-                StateReadError::Rusqlite(rusqlite_err) => ValidationError::Rusqlite(rusqlite_err),
-                StateReadError::Join(join_err) => ValidationError::Join(join_err),
-                _ => ValidationError::Query(QueryError::from(rusqlite::Error::InvalidQuery)),
-            },
-            AcquireThenError::Join(err) => ValidationError::Join(err),
-        }
-    }
-}
-
 fn fmt_pred_addr(addr: &PredicateAddress) -> String {
     format!(
         "(contract: {}, predicate: {})",

--- a/crates/node/src/validate.rs
+++ b/crates/node/src/validate.rs
@@ -4,7 +4,7 @@ use crate::{
     db::{
         self,
         finalized::{query_state_exclusive_solution, query_state_inclusive_solution},
-        pool::{ConnectionHandle},
+        pool::ConnectionHandle,
         ConnectionPool, QueryError,
     },
     error::{QueryPredicateError, SolutionPredicatesError, StateReadError, ValidationError},

--- a/crates/node/src/validate.rs
+++ b/crates/node/src/validate.rs
@@ -17,6 +17,7 @@ use essential_types::{
     convert::bytes_from_word, predicate::Predicate, solution::Solution, solution::SolutionData,
     Block, ContentAddress, Key, PredicateAddress, Value, Word,
 };
+use futures::FutureExt;
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 #[cfg(test)]
@@ -388,8 +389,7 @@ impl StateRead for State {
             conn_pool,
         } = self.clone();
 
-        Box::pin(async move {
-            // Is there a better way to get an instance of a ConnectionPool?
+        async move {
             let pool = match conn_pool {
                 Db::ConnectionPool(pool) => pool,
                 _ => panic!("Expected a ConnectionPool"),
@@ -419,7 +419,8 @@ impl StateRead for State {
             })
             .await
             .map_err(StateReadError::from)
-        })
+        }
+        .boxed()
     }
 }
 

--- a/crates/node/src/validate.rs
+++ b/crates/node/src/validate.rs
@@ -4,7 +4,7 @@ use crate::{
     db::{
         self,
         finalized::{query_state_exclusive_solution, query_state_inclusive_solution},
-        pool::{AcquireThenError, ConnectionHandle},
+        pool::{ConnectionHandle},
         ConnectionPool, QueryError,
     },
     error::{QueryPredicateError, SolutionPredicatesError, StateReadError, ValidationError},
@@ -17,8 +17,7 @@ use essential_types::{
     convert::bytes_from_word, predicate::Predicate, solution::Solution, solution::SolutionData,
     Block, ContentAddress, Key, PredicateAddress, Value, Word,
 };
-use futures::FutureExt;
-use std::{collections::HashMap, error::Error, pin::Pin, sync::Arc};
+use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 #[cfg(test)]
 mod tests;
@@ -401,7 +400,7 @@ impl StateRead for State {
                 let tx = &Transaction::Handle(conn.transaction()?);
 
                 for _ in 0..num_values {
-                    let value = query(&tx, |tx| {
+                    let value = query(tx, |tx| {
                         query_state(
                             tx,
                             &contract_addr,

--- a/crates/node/src/validate.rs
+++ b/crates/node/src/validate.rs
@@ -18,7 +18,7 @@ use essential_types::{
     Block, ContentAddress, Key, PredicateAddress, Value, Word,
 };
 use futures::FutureExt;
-use std::{collections::HashMap, pin::Pin, sync::Arc, error::Error};
+use std::{collections::HashMap, error::Error, pin::Pin, sync::Arc};
 
 #[cfg(test)]
 mod tests;
@@ -371,7 +371,7 @@ fn query(
 }
 
 impl StateRead for State {
-    type Error = AcquireThenError<StateReadError>;
+    type Error = StateReadError;
 
     type Future =
         Pin<Box<dyn std::future::Future<Output = Result<Vec<Vec<Word>>, Self::Error>> + Send>>;
@@ -419,7 +419,7 @@ impl StateRead for State {
                 Ok(values)
             })
             .await
-            .map_err(Self::Error::Inner)
+            .map_err(StateReadError::from)
         })
     }
 }

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -108,7 +108,6 @@ async fn validate_next_block(
             let block_address = block_address.clone();
             let r: Result<bool, InternalError> = conn_pool
                 .acquire_then(move |conn| {
-                    let mut result = || -> Result<bool, ValidationError> {
                         // Update validation progress.
                         update_validation_progress(conn, &block_address)?;
                         let tx = conn.transaction()?;
@@ -128,8 +127,6 @@ async fn validate_next_block(
                             }
                         }
                         Ok(false)
-                    };
-                    result().map_err(ValidationError::from)
                 })
                 .await
                 .map_err(InternalError::from);

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -108,25 +108,25 @@ async fn validate_next_block(
             let block_address = block_address.clone();
             let r: Result<bool, InternalError> = conn_pool
                 .acquire_then(move |conn| {
-                        // Update validation progress.
-                        update_validation_progress(conn, &block_address)?;
-                        let tx = conn.transaction()?;
-                        // Keep validating if there are more blocks awaiting.
-                        let latest_finalized_block_number = {
-                            let hash = get_latest_finalized_block_address(&tx)?;
-                            if let Some(hash) = hash {
-                                let header = get_block_header(&tx, &hash)?;
-                                header.map(|(number, _ts)| number)
-                            } else {
-                                None
-                            }
-                        };
-                        if let Some(latest_block_number) = latest_finalized_block_number {
-                            if latest_block_number > block.number {
-                                return Ok(true);
-                            }
+                    // Update validation progress.
+                    update_validation_progress(conn, &block_address)?;
+                    let tx = conn.transaction()?;
+                    // Keep validating if there are more blocks awaiting.
+                    let latest_finalized_block_number = {
+                        let hash = get_latest_finalized_block_address(&tx)?;
+                        if let Some(hash) = hash {
+                            let header = get_block_header(&tx, &hash)?;
+                            header.map(|(number, _ts)| number)
+                        } else {
+                            None
                         }
-                        Ok(false)
+                    };
+                    if let Some(latest_block_number) = latest_finalized_block_number {
+                        if latest_block_number > block.number {
+                            return Ok(true);
+                        }
+                    }
+                    Ok(false)
                 })
                 .await
                 .map_err(InternalError::from);

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -147,7 +147,6 @@ async fn validate_next_block(
                     .get(solution_index)
                     .expect("Failed solution must exist."),
             );
-            let block_address = block_address.clone();
             let r: Result<bool, InternalError> = conn_pool
                 .acquire_then(move |conn| {
                     db::insert_failed_block(conn, &block_address, &failed_solution)

--- a/crates/node/src/validation/tests.rs
+++ b/crates/node/src/validation/tests.rs
@@ -14,10 +14,9 @@ use std::time::Duration;
 
 // Insert a block to the database and send a notification to the stream
 fn insert_block_and_send_notification(conn: &mut Connection, block: &Block, block_tx: &BlockTx) {
-    node_db::with_tx::<_, QueryError>(conn, |tx| {
+    node_db::with_tx(conn, |tx| {
         let block_ca = insert_block(tx, block)?;
-        finalize_block(tx, &block_ca)?;
-        Ok(())
+        finalize_block(tx, &block_ca)
     })
     .unwrap();
 

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -168,7 +168,7 @@ fn assert_submit_solutions_effects(conn: &mut Connection, expected_blocks: Vec<B
     let mut fetched_blocks = Vec::new();
     node_db::with_tx_dropped::<_, QueryError>(conn, |tx| {
         fetched_blocks = db::list_blocks(
-            &tx,
+            tx,
             expected_blocks[0].number..expected_blocks[expected_blocks.len() - 1].number + 1,
         )?;
         Ok(())

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -165,13 +165,11 @@ async fn test_node() -> (NodeServer, BlockTx) {
 // Assert state mutations in the blocks have been applied to database.
 // Assert validation progress is the latest fetched block.
 fn assert_submit_solutions_effects(conn: &mut Connection, expected_blocks: Vec<Block>) {
-    let mut fetched_blocks = Vec::new();
-    node_db::with_tx_dropped::<_, QueryError>(conn, |tx| {
-        fetched_blocks = db::list_blocks(
+    let fetched_blocks = node_db::with_tx_dropped::<_, QueryError>(conn, |tx| {
+        db::list_blocks(
             tx,
             expected_blocks[0].number..expected_blocks[expected_blocks.len() - 1].number + 1,
-        )?;
-        Ok(())
+        )
     })
     .unwrap();
 

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -14,6 +14,7 @@ use essential_node::{
     },
     RunConfig,
 };
+use essential_node_db::{self as node_db, QueryError};
 use essential_node_types::{block_notify::BlockTx, BigBang};
 use essential_types::Block;
 use rusqlite::Connection;
@@ -164,13 +165,15 @@ async fn test_node() -> (NodeServer, BlockTx) {
 // Assert state mutations in the blocks have been applied to database.
 // Assert validation progress is the latest fetched block.
 fn assert_submit_solutions_effects(conn: &mut Connection, expected_blocks: Vec<Block>) {
-    let tx = conn.transaction().unwrap();
-    let fetched_blocks = &db::list_blocks(
-        &tx,
-        expected_blocks[0].number..expected_blocks[expected_blocks.len() - 1].number + 1,
-    )
+    let mut fetched_blocks = Vec::new();
+    node_db::with_tx_dropped::<_, QueryError>(conn, |tx| {
+        fetched_blocks = db::list_blocks(
+            &tx,
+            expected_blocks[0].number..expected_blocks[expected_blocks.len() - 1].number + 1,
+        )?;
+        Ok(())
+    })
     .unwrap();
-    drop(tx);
 
     for (i, expected_block) in expected_blocks.iter().enumerate() {
         // Check if the block was added to the database

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -14,7 +14,7 @@ use essential_node::{
     },
     RunConfig,
 };
-use essential_node_db::{self as node_db, QueryError};
+use essential_node_db::{self as node_db};
 use essential_node_types::{block_notify::BlockTx, BigBang};
 use essential_types::Block;
 use rusqlite::Connection;
@@ -165,7 +165,7 @@ async fn test_node() -> (NodeServer, BlockTx) {
 // Assert state mutations in the blocks have been applied to database.
 // Assert validation progress is the latest fetched block.
 fn assert_submit_solutions_effects(conn: &mut Connection, expected_blocks: Vec<Block>) {
-    let fetched_blocks = node_db::with_tx_dropped::<_, QueryError>(conn, |tx| {
+    let fetched_blocks = node_db::with_tx_dropped(conn, |tx| {
         db::list_blocks(
             tx,
             expected_blocks[0].number..expected_blocks[expected_blocks.len() - 1].number + 1,

--- a/crates/node/tests/run.rs
+++ b/crates/node/tests/run.rs
@@ -14,7 +14,7 @@ use essential_node::{
     },
     RunConfig,
 };
-use essential_node_db::{self as node_db};
+use essential_node_db as node_db;
 use essential_node_types::{block_notify::BlockTx, BigBang};
 use essential_types::Block;
 use rusqlite::Connection;

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -54,7 +54,7 @@ async fn test_sync() {
 
     let mut result = vec![];
     node_db::with_tx_dropped::<_, QueryError>(&mut test_conn, |block_tx| {
-        result = db::list_blocks(&block_tx, 0..100)?;
+        result = db::list_blocks(block_tx, 0..100)?;
         Ok(())
     })
     .unwrap();
@@ -70,7 +70,7 @@ async fn test_sync() {
     block_rx.changed().await.unwrap();
 
     node_db::with_tx_dropped::<_, QueryError>(&mut test_conn, |block_tx| {
-        result = db::list_blocks(&block_tx, 0..100)?;
+        result = db::list_blocks(block_tx, 0..100)?;
         Ok(())
     })
     .unwrap();

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -48,10 +48,9 @@ async fn test_sync() {
 
     block_rx.changed().await.unwrap();
 
-    let result = node_db::with_tx_dropped(&mut test_conn, |block_tx| {
-        db::list_blocks(block_tx, 0..100)
-    })
-    .unwrap();
+    let result =
+        node_db::with_tx_dropped(&mut test_conn, |block_tx| db::list_blocks(block_tx, 0..100))
+            .unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].number, 0);
@@ -63,10 +62,9 @@ async fn test_sync() {
 
     block_rx.changed().await.unwrap();
 
-    let result = node_db::with_tx_dropped(&mut test_conn, |block_tx| {
-        db::list_blocks(block_tx, 0..100)
-    })
-    .unwrap();
+    let result =
+        node_db::with_tx_dropped(&mut test_conn, |block_tx| db::list_blocks(block_tx, 0..100))
+            .unwrap();
 
     assert_eq!(result.len(), 2);
     assert_eq!(result[1].number, 1);

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -34,9 +34,8 @@ async fn test_sync() {
 
     let mut test_conn = relayer_conn.acquire().await.unwrap();
 
-    node_db::with_tx::<_, QueryError>(&mut test_conn, |tx| {
-        db::create_tables(tx)?;
-        Ok(())
+    node_db::with_tx(&mut test_conn, |tx| {
+        db::create_tables(tx)
     })
     .unwrap();
 
@@ -112,7 +111,6 @@ async fn test_sync() {
             break;
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-        continue;
     }
 
     assert_eq!(num_solutions, 200);

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -5,7 +5,7 @@ use essential_node::db::{
 };
 use essential_node_types::block_notify::BlockTx;
 
-use essential_node_db::{self as node_db};
+use essential_node_db as node_db;
 use essential_relayer::{DataSyncError, Relayer};
 use essential_types::{
     contract::Contract,

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -5,7 +5,7 @@ use essential_node::db::{
 };
 use essential_node_types::block_notify::BlockTx;
 
-use essential_node_db::{self as node_db, QueryError};
+use essential_node_db::{self as node_db};
 use essential_relayer::{DataSyncError, Relayer};
 use essential_types::{
     contract::Contract,
@@ -48,10 +48,8 @@ async fn test_sync() {
 
     block_rx.changed().await.unwrap();
 
-    let mut result = vec![];
-    node_db::with_tx_dropped::<_, QueryError>(&mut test_conn, |block_tx| {
-        result = db::list_blocks(block_tx, 0..100)?;
-        Ok(())
+    let result = node_db::with_tx_dropped(&mut test_conn, |block_tx| {
+        db::list_blocks(block_tx, 0..100)
     })
     .unwrap();
 
@@ -65,9 +63,8 @@ async fn test_sync() {
 
     block_rx.changed().await.unwrap();
 
-    node_db::with_tx_dropped::<_, QueryError>(&mut test_conn, |block_tx| {
-        result = db::list_blocks(block_tx, 0..100)?;
-        Ok(())
+    let result = node_db::with_tx_dropped(&mut test_conn, |block_tx| {
+        db::list_blocks(block_tx, 0..100)
     })
     .unwrap();
 

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -34,10 +34,7 @@ async fn test_sync() {
 
     let mut test_conn = relayer_conn.acquire().await.unwrap();
 
-    node_db::with_tx(&mut test_conn, |tx| {
-        db::create_tables(tx)
-    })
-    .unwrap();
+    node_db::with_tx(&mut test_conn, |tx| db::create_tables(tx)).unwrap();
 
     let (solutions, blocks) = test_structs();
 

--- a/crates/relayer/tests/integration.rs
+++ b/crates/relayer/tests/integration.rs
@@ -37,7 +37,8 @@ async fn test_sync() {
     node_db::with_tx::<_, QueryError>(&mut test_conn, |tx| {
         db::create_tables(tx)?;
         Ok(())
-    }).unwrap();
+    })
+    .unwrap();
 
     let (solutions, blocks) = test_structs();
 
@@ -55,7 +56,8 @@ async fn test_sync() {
     node_db::with_tx_dropped::<_, QueryError>(&mut test_conn, |block_tx| {
         result = db::list_blocks(&block_tx, 0..100)?;
         Ok(())
-    }).unwrap();
+    })
+    .unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].number, 0);
@@ -70,8 +72,8 @@ async fn test_sync() {
     node_db::with_tx_dropped::<_, QueryError>(&mut test_conn, |block_tx| {
         result = db::list_blocks(&block_tx, 0..100)?;
         Ok(())
-    }).unwrap();
-
+    })
+    .unwrap();
 
     assert_eq!(result.len(), 2);
     assert_eq!(result[1].number, 1);
@@ -91,23 +93,28 @@ async fn test_sync() {
     let start = tokio::time::Instant::now();
     let mut num_solutions: usize = 0;
     let mut result: Vec<Block> = vec![];
+
     loop {
         if start.elapsed() > tokio::time::Duration::from_secs(10) {
             panic!("timeout num_solutions: {}, {}", num_solutions, result.len());
         }
+
         let tx = test_conn.transaction().unwrap();
         let Ok(r) = db::list_blocks(&tx, 0..203) else {
             tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
             continue;
         };
         drop(tx);
+
         result = r;
         num_solutions = result.iter().map(|b| b.solutions.len()).sum();
         if num_solutions >= 200 {
             break;
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        continue;
     }
+
     assert_eq!(num_solutions, 200);
     assert!(result
         .iter()


### PR DESCRIPTION
As per the linked issue, this PR is a refactoring of a few areas:

- introduces the `node_db::with_tx_dropped()` method
- uses `with_tx`/`with_tx_dropped` where appropriate
- uses the `acquire_then` method in place of acquiring a database connection and making a call using `spawn_blocking`

The issue mentions possibly cleaning up error types made redundant by this refactor. I don't think there are any, but this would be a good area to focus on during review as I may have missed something there.

closes #158 

