### PR TITLE
refactor: rename `_hash` -> `_addr`

### DIFF
--- a/crates/node-db-sql/sql/create/solution_set.sql
+++ b/crates/node-db-sql/sql/create/solution_set.sql
@@ -1,4 +1,4 @@
 CREATE TABLE IF NOT EXISTS solution_set (
     id INTEGER PRIMARY KEY,
-    content_hash BLOB NOT NULL UNIQUE
+    content_addr BLOB NOT NULL UNIQUE
 );

--- a/crates/node-db-sql/sql/insert/block_solution_set.sql
+++ b/crates/node-db-sql/sql/insert/block_solution_set.sql
@@ -3,6 +3,6 @@ INSERT OR IGNORE INTO
 VALUES
     (
         (SELECT id FROM block WHERE block.block_address = :block_address LIMIT 1),
-        (SELECT id FROM solution_set WHERE solution_set.content_hash = :solution_set_hash LIMIT 1),
+        (SELECT id FROM solution_set WHERE solution_set.content_addr = :solution_set_addr LIMIT 1),
         :solution_set_index
     );

--- a/crates/node-db-sql/sql/insert/failed_block.sql
+++ b/crates/node-db-sql/sql/insert/failed_block.sql
@@ -3,5 +3,5 @@ INSERT
 VALUES
     (
         (SELECT id FROM block WHERE block.block_address = :block_address LIMIT 1),
-        (SELECT id FROM solution_set WHERE solution_set.content_hash = :solution_set_hash LIMIT 1)
+        (SELECT id FROM solution_set WHERE solution_set.content_addr = :solution_set_addr LIMIT 1)
     );

--- a/crates/node-db-sql/sql/insert/mutation.sql
+++ b/crates/node-db-sql/sql/insert/mutation.sql
@@ -14,7 +14,7 @@ VALUES
                 solution
                 JOIN solution_set ON solution_set.id = solution.solution_set_id
             WHERE
-                solution_set.content_hash = :solution_set_hash AND solution.solution_index = :solution_index
+                solution_set.content_addr = :solution_set_addr AND solution.solution_index = :solution_index
             LIMIT
                 1
         ), :mutation_index, :key, :value

--- a/crates/node-db-sql/sql/insert/pred_data.sql
+++ b/crates/node-db-sql/sql/insert/pred_data.sql
@@ -13,7 +13,7 @@ VALUES
                 solution
                 JOIN solution_set ON solution_set.id = solution.solution_set_id
             WHERE
-                solution_set.content_hash = :solution_set_hash AND solution.solution_index = :solution_index
+                solution_set.content_addr = :solution_set_addr AND solution.solution_index = :solution_index
             LIMIT
                 1
         ), :pred_data_index, :value

--- a/crates/node-db-sql/sql/insert/solution.sql
+++ b/crates/node-db-sql/sql/insert/solution.sql
@@ -8,7 +8,7 @@ VALUES
             FROM
                 solution_set
             WHERE
-                content_hash = :solution_set_hash
+                content_addr = :solution_set_addr
             LIMIT
                 1
         ), :solution_index, :contract_addr, :predicate_addr

--- a/crates/node-db-sql/sql/insert/solution_set.sql
+++ b/crates/node-db-sql/sql/insert/solution_set.sql
@@ -1,4 +1,4 @@
 INSERT
-    OR IGNORE INTO solution_set (content_hash)
+    OR IGNORE INTO solution_set (content_addr)
 VALUES
-    (:content_hash)
+    (:content_addr)

--- a/crates/node-db-sql/sql/query/get_block.sql
+++ b/crates/node-db-sql/sql/query/get_block.sql
@@ -1,5 +1,5 @@
 SELECT
-    solution_set.content_hash
+    solution_set.content_addr
 FROM
     block
     LEFT JOIN block_solution_set ON block.id = block_solution_set.block_id

--- a/crates/node-db-sql/sql/query/get_solution.sql
+++ b/crates/node-db-sql/sql/query/get_solution.sql
@@ -5,6 +5,6 @@ FROM
     solution_set
     JOIN solution ON solution.solution_set_id = solution_set.id
 WHERE
-    solution_set.content_hash = ?
+    solution_set.content_addr = ?
 ORDER BY
     solution.solution_index ASC;

--- a/crates/node-db-sql/sql/query/get_solution_mutations.sql
+++ b/crates/node-db-sql/sql/query/get_solution_mutations.sql
@@ -6,6 +6,6 @@ FROM
     JOIN solution ON solution.solution_set_id = solution_set.id
     JOIN mutation ON mutation.solution_id = solution.id
 WHERE
-    solution_set.content_hash = :content_hash AND solution.solution_index = :solution_index;
+    solution_set.content_addr = :content_addr AND solution.solution_index = :solution_index;
 ORDER BY
     mutation.mutation_index ASC

--- a/crates/node-db-sql/sql/query/get_solution_pred_data.sql
+++ b/crates/node-db-sql/sql/query/get_solution_pred_data.sql
@@ -5,6 +5,6 @@ FROM
     JOIN solution ON solution.solution_set_id = solution_set.id
     JOIN pred_data ON pred_data.solution_id = solution.id
 WHERE
-    solution_set.content_hash = :content_hash AND solution.solution_index = :solution_index;
+    solution_set.content_addr = :content_addr AND solution.solution_index = :solution_index;
 ORDER BY
     pred_data.pred_data_index ASC

--- a/crates/node-db-sql/sql/query/list_blocks.sql
+++ b/crates/node-db-sql/sql/query/list_blocks.sql
@@ -3,7 +3,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution_set.content_hash
+    solution_set.content_addr
 FROM
     block
     LEFT JOIN block_solution_set ON block.id = block_solution_set.block_id

--- a/crates/node-db-sql/sql/query/list_blocks_by_time.sql
+++ b/crates/node-db-sql/sql/query/list_blocks_by_time.sql
@@ -3,7 +3,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution_set.content_hash
+    solution_set.content_addr
 
 FROM
     block

--- a/crates/node-db-sql/sql/query/list_failed_blocks.sql
+++ b/crates/node-db-sql/sql/query/list_failed_blocks.sql
@@ -1,6 +1,6 @@
 SELECT
     block.number,
-    solution_set.content_hash
+    solution_set.content_addr
 FROM
     failed_block
     JOIN block ON failed_block.block_id = block.id
@@ -10,4 +10,4 @@ WHERE
 ORDER BY
     block.number ASC,
     block.block_address ASC,
-    solution_set.content_hash ASC;
+    solution_set.content_addr ASC;

--- a/crates/node-db-sql/sql/query/list_unchecked_blocks.sql
+++ b/crates/node-db-sql/sql/query/list_unchecked_blocks.sql
@@ -3,7 +3,7 @@ SELECT
     block.number,
     block.timestamp_secs,
     block.timestamp_nanos,
-    solution_set.content_hash
+    solution_set.content_addr
 FROM
     block
     LEFT JOIN block_solution_set ON block.id = block_solution_set.block_id

--- a/crates/node-db/src/query_range/address.rs
+++ b/crates/node-db/src/query_range/address.rs
@@ -53,10 +53,10 @@ pub fn query_state_exclusive_block(
     key: &Key,
     block_address: &ContentAddress,
 ) -> Result<Option<Value>, QueryError> {
-    let Some(parent_hash) = crate::get_parent_block_address(tx, block_address)? else {
+    let Some(parent_addr) = crate::get_parent_block_address(tx, block_address)? else {
         return Ok(None);
     };
-    query_state_inclusive_block(tx, contract_ca, key, &parent_hash)
+    query_state_inclusive_block(tx, contract_ca, key, &parent_addr)
 }
 
 /// Query for the most recent version value of a key in a contracts state

--- a/crates/node/src/test_utils.rs
+++ b/crates/node/src/test_utils.rs
@@ -272,11 +272,11 @@ pub fn test_predicate(seed: Word) -> (Predicate, Vec<Program>) {
 }
 
 // Check that the validation progress in the database is block number and hash
-pub fn assert_validation_progress_is_some(conn: &Connection, hash: &ContentAddress) {
-    let progress_hash = get_validation_progress(conn)
+pub fn assert_validation_progress_is_some(conn: &Connection, addr: &ContentAddress) {
+    let progress_addr = get_validation_progress(conn)
         .unwrap()
         .expect("validation progress should be some");
-    assert_eq!(progress_hash, *hash);
+    assert_eq!(progress_addr, *addr);
 }
 
 // Check that the validation in the database is none

--- a/crates/node/src/validation/tests.rs
+++ b/crates/node/src/validation/tests.rs
@@ -33,7 +33,7 @@ async fn can_validate() {
 
     const NUM_TEST_BLOCKS: Word = 4;
     let blocks = test_blocks_with_contracts(1, 1 + NUM_TEST_BLOCKS);
-    let hashes = blocks.iter().map(content_addr).collect::<Vec<_>>();
+    let block_addrs = blocks.iter().map(content_addr).collect::<Vec<_>>();
 
     let block_tx = BlockTx::new();
     let block_rx = block_tx.new_listener();
@@ -57,7 +57,7 @@ async fn can_validate() {
     insert_block_and_send_notification(&mut conn, &blocks[0], &block_tx);
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Assert validation progress is block 0
-    assert_validation_progress_is_some(&conn, &hashes[0]);
+    assert_validation_progress_is_some(&conn, &block_addrs[0]);
 
     // Process block 1
     insert_block_and_send_notification(&mut conn, &blocks[1], &block_tx);
@@ -66,13 +66,13 @@ async fn can_validate() {
     insert_block_and_send_notification(&mut conn, &blocks[2], &block_tx);
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Assert validation progress is block 2
-    assert_validation_progress_is_some(&conn, &hashes[2]);
+    assert_validation_progress_is_some(&conn, &block_addrs[2]);
 
     // Process block 3
     insert_block_and_send_notification(&mut conn, &blocks[3], &block_tx);
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Assert validation progress is block 3
-    assert_validation_progress_is_some(&conn, &hashes[3]);
+    assert_validation_progress_is_some(&conn, &block_addrs[3]);
 
     handle.close().await.unwrap();
 }
@@ -136,7 +136,7 @@ async fn can_process_valid_and_invalid_blocks() {
     let invalid_block = test_invalid_block_with_contract(2, Duration::from_secs(2));
 
     let blocks = test_blocks;
-    let hashes = blocks.iter().map(content_addr).collect::<Vec<_>>();
+    let block_addrs = blocks.iter().map(content_addr).collect::<Vec<_>>();
 
     let block_tx = BlockTx::new();
     let block_rx = block_tx.new_listener();
@@ -160,13 +160,13 @@ async fn can_process_valid_and_invalid_blocks() {
     insert_block_and_send_notification(&mut conn, &blocks[0], &block_tx);
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Assert validation progress is block 0
-    assert_validation_progress_is_some(&conn, &hashes[0]);
+    assert_validation_progress_is_some(&conn, &block_addrs[0]);
 
     // Process invalid block
     insert_block_and_send_notification(&mut conn, &invalid_block, &block_tx);
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Assert validation progress is still block 0
-    assert_validation_progress_is_some(&conn, &hashes[0]);
+    assert_validation_progress_is_some(&conn, &block_addrs[0]);
     // Assert block is in failed blocks table
     let fetched_failed_blocks = db::list_failed_blocks(&conn, 0..10).unwrap();
     assert_eq!(fetched_failed_blocks.len(), 1);
@@ -180,7 +180,7 @@ async fn can_process_valid_and_invalid_blocks() {
     insert_block_and_send_notification(&mut conn, &blocks[1], &block_tx);
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Assert validation progress is block 1
-    assert_validation_progress_is_some(&conn, &hashes[1]);
+    assert_validation_progress_is_some(&conn, &block_addrs[1]);
 
     handle.close().await.unwrap();
 }


### PR DESCRIPTION
Closes #167 

Bumps versions of crates other than `rusqlite-pool` for them to be published.