### PR TITLE
feat: Publish new versions of all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "essential-check",
  "essential-hash",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node-api"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "axum",
  "essential-hash",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "essential-node-db"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "essential-check",
  "essential-hash",
@@ -714,11 +714,11 @@ dependencies = [
 
 [[package]]
 name = "essential-node-db-sql"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "essential-node-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "essential-hash",
  "essential-types",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "essential-relayer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "essential-hash",
  "essential-node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.10.0", features = ["v4"] }
 
-essential-node = { path = "crates/node", version = "0.8.0" }
-essential-node-api = { path = "crates/node-api", version = "0.8.0" }
-essential-node-db-sql = { path = "crates/node-db-sql", version = "0.4.0" }
-essential-node-db = { path = "crates/node-db", version = "0.4.0" }
-essential-node-types = { path = "crates/node-types", version = "0.2.0" }
-essential-relayer = { path = "crates/relayer", version = "0.3.0" }
+essential-node = { path = "crates/node", version = "0.9.0" }
+essential-node-api = { path = "crates/node-api", version = "0.9.0" }
+essential-node-db-sql = { path = "crates/node-db-sql", version = "0.5.0" }
+essential-node-db = { path = "crates/node-db", version = "0.5.0" }
+essential-node-types = { path = "crates/node-types", version = "0.3.0" }
+essential-relayer = { path = "crates/relayer", version = "0.4.0" }
 rusqlite-pool = { path = "crates/rusqlite-pool", version = "0.2.0" }

--- a/crates/node-api/Cargo.toml
+++ b/crates/node-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-api"
-version = "0.8.0"
+version = "0.9.0"
 description = "API implementation for the Essential node"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node-cli/Cargo.toml
+++ b/crates/node-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-cli"
-version = "0.8.0"
+version = "0.9.0"
 description = "The Essential node CLI"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node-db-sql/Cargo.toml
+++ b/crates/node-db-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-db-sql"
-version = "0.4.0"
+version = "0.5.0"
 description = "SQL statements for the Essential node database"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node-db/Cargo.toml
+++ b/crates/node-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-db"
-version = "0.4.0"
+version = "0.5.0"
 description = "The Essential node database"
 authors.workspace = true
 edition.workspace = true

--- a/crates/node-types/Cargo.toml
+++ b/crates/node-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node-types"
-version = "0.2.0"
+version = "0.3.0"
 description = "Core types used within this implementation of the Essential protocol."
 edition.workspace = true
 authors.workspace = true

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-node"
-version = "0.8.0"
+version = "0.9.0"
 description = "Validation for Essential protocol"
 authors.workspace = true
 edition.workspace = true

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "essential-relayer"
-version = "0.3.0"
+version = "0.4.0"
 description = "Relay blocks from Essential builder to Essential node"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This set of version bumps includes many breaking changes, namely:

- https://github.com/essential-contributions/essential-base/pull/212
- https://github.com/essential-contributions/essential-node/pull/166
- https://github.com/essential-contributions/essential-node/pull/169